### PR TITLE
feat: gradient accumulation, AMP, LoRA training correctness

### DIFF
--- a/cli/train_teacher.py
+++ b/cli/train_teacher.py
@@ -31,7 +31,6 @@ from typing import Dict, Any
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from ml_engine.training import Trainer
 from ml_engine.data.manager import DataManager
 from core.config import (
     save_config, create_experiment_dir, load_config, merge_configs
@@ -111,6 +110,16 @@ Note: User provides ONE dataset file. Platform automatically:
                         default='medium',
                         help='Augmentation intensity')
 
+    # Gradient accumulation (effective batch scaling with no VRAM cost)
+    parser.add_argument('--grad-accum', type=int, default=None,
+                        metavar='N',
+                        help=(
+                            'Accumulate gradients over N micro-batches before each optimizer step. '
+                            'Effective batch = batch_size × N with zero extra VRAM. '
+                            'Use when OOM prevents increasing --batch-size '
+                            '(e.g. --batch-size 1 --grad-accum 8 = effective batch of 8).'
+                        ))
+
     # Other options
     parser.add_argument('--gpu', type=int, default=0,
                         help='GPU ID to use')
@@ -154,6 +163,12 @@ def build_cli_overrides(args) -> Dict[str, Any]:
             'intensity': args.aug_intensity
         }
         # TODO(sh/2025-11-12): Add environment overrides
+
+    # Gradient accumulation
+    if args.grad_accum is not None:
+        overrides['training_dynamics'] = {
+            'gradient_accumulation': {'steps': args.grad_accum}
+        }
 
     # Model checkpoints
     model_overrides = {}
@@ -311,6 +326,8 @@ def main():
 
     os.environ['CUDA_VISIBLE_DEVICES'] = str(args.gpu)
 
+    from ml_engine.training import Trainer  # deferred: avoids torch import at --help time
+
     trainer = Trainer(
         data_manager=data_manager,
         output_dir=str(exp_dir),
@@ -330,9 +347,33 @@ def main():
         # Save current state before exiting
         sys.exit(0)
     except Exception as e:
-        logger.error(f"\n❌ Training failed with error: {e}")
         import traceback
+        error_str = str(e).lower()
+        is_oom = (
+            'out of memory' in error_str
+            or 'cuda out of memory' in error_str
+            or 'oom' in error_str
+        )
+        logger.error("\n Training failed: %s", e)
         traceback.print_exc()
+        if is_oom:
+            current_bs = config.get('batch_size', 1)
+            current_accum = config.get('training_dynamics', {}).get(
+                'gradient_accumulation', {}
+            ).get('steps', 1)
+            suggested_accum = max(current_accum * 2, 4)
+            logger.error(
+                "\n OOM detected. Try reducing memory pressure:\n"
+                "  Option A (recommended — same effective batch, lower VRAM):\n"
+                "    --batch-size 1 --grad-accum %d\n"
+                "  Option B (smaller effective batch):\n"
+                "    --batch-size 1\n"
+                "  Current: batch_size=%d, grad_accum=%d → effective batch=%d",
+                suggested_accum,
+                current_bs,
+                current_accum,
+                current_bs * current_accum,
+            )
         sys.exit(1)
 
     logger.info("\n Training completed successfully!")

--- a/configs/defaults/experiment_loop.yaml
+++ b/configs/defaults/experiment_loop.yaml
@@ -52,10 +52,11 @@ mutable_keys:
   # --- Training dynamics (config['training_dynamics']) ---
   # These reach TrainingManager via Trainer._init_trainers injecting
   # 'training_dynamics' into model_config. See trainer.py._init_trainers.
-  "training_dynamics.gradient_clipping.max_norm":      {type: float, min: 0.01, max: 10.0}
-  "training_dynamics.gradient_clipping.enabled":       {type: bool}
-  "training_dynamics.mixed_precision.enabled":         {type: bool}
-  "training_dynamics.normalization.freeze_bn_teacher": {type: bool}
+  "training_dynamics.gradient_clipping.max_norm":           {type: float, min: 0.01, max: 10.0}
+  "training_dynamics.gradient_clipping.enabled":            {type: bool}
+  "training_dynamics.mixed_precision.enabled":              {type: bool}
+  "training_dynamics.normalization.freeze_bn_teacher":      {type: bool}
+  "training_dynamics.gradient_accumulation.steps":          {type: int, min: 1, max: 32}
 
 # Keys the experiment loop must NEVER mutate.
 # Changing these would alter model identity or break dataset compatibility.

--- a/configs/defaults/teacher_sam_lora.yaml
+++ b/configs/defaults/teacher_sam_lora.yaml
@@ -44,7 +44,6 @@ mask_decoder_lr_multiplier: 0.1  # Lower LR for mask_decoder (pretrained weights
 
 # Prompt strategy during fine-tuning
 prompt_type: "boxes"         # Use GT boxes as prompts (auto-gen if masks-only)
-multimask_output: true       # Output multiple mask candidates
 
 # Evaluation metric
 evaluation:

--- a/configs/defaults/training_dynamics.yaml
+++ b/configs/defaults/training_dynamics.yaml
@@ -9,6 +9,12 @@ training_dynamics:
     norm_type: 2.0       # L2 norm
     error_if_nonfinite: true  # Stop training if NaN/Inf gradients
   
+  # Gradient accumulation: accumulate N micro-batches before each optimizer step.
+  # Effective batch = batch_size × steps with zero extra VRAM cost.
+  # Set steps > 1 when GPU memory limits physical batch_size (e.g. steps: 8 → 8× effective batch).
+  gradient_accumulation:
+    steps: 1
+
   # Mixed precision training (FP16)
   mixed_precision:
     enabled: true

--- a/ml_engine/evaluation/evaluator.py
+++ b/ml_engine/evaluation/evaluator.py
@@ -212,6 +212,10 @@ class ModelEvaluator:
         
         return {
             'model_type': 'segmentation',
+            # SAM is evaluated with GT bounding boxes as prompts (oracle mode).
+            # In production, prompts come from GroundingDINO, so real mIoU will be lower.
+            # This metric represents the upper bound of SAM's segmentation quality.
+            'evaluation_mode': 'oracle_gt_prompts',
             'technical_metrics': technical_metrics,
             'simple_metrics': simple_metrics,
             'samples': {
@@ -302,20 +306,28 @@ class ModelEvaluator:
         predictions_list = []
         targets_list = []
         
-        # Forward pass with box prompts
-        # Note: SAM expects boxes in xyxy format
-        outputs = model(images, box_prompts=gt_boxes)
+        # Trim to max_valid before the forward pass — mirrors SAMTrainer.compute_loss().
+        # Padding slots are zero-boxes; running them through the decoder wastes compute.
+        valid_mask_batch = (gt_labels != -1)
+        max_valid = int(valid_mask_batch.sum(dim=1).max().item())
+        max_valid = max(max_valid, 1)
+
+        # Forward pass with box prompts (xyxy format, padding trimmed)
+        outputs = model(images, box_prompts=gt_boxes[:, :max_valid, :])
         
         pred_masks = outputs['pred_masks']  # [B, N, H, W]
         iou_predictions = outputs.get('iou_predictions', torch.ones_like(gt_labels, dtype=torch.float))
         
         for b in range(batch_size):
             valid_mask = gt_labels[b] != -1
-            
+            # pred_masks comes from a forward pass on trimmed input (max_valid boxes),
+            # so index it with a trimmed mask to match its leading dimension.
+            valid_mask_trimmed = valid_mask[:max_valid]
+
             # Process predictions - only for valid GT boxes
-            if valid_mask.sum() > 0:
-                valid_pred_masks = pred_masks[b][valid_mask]
-                valid_iou_preds = iou_predictions[b][valid_mask] if len(iou_predictions.shape) > 1 else iou_predictions[valid_mask]
+            if valid_mask_trimmed.sum() > 0:
+                valid_pred_masks = pred_masks[b][valid_mask_trimmed]
+                valid_iou_preds = iou_predictions[b][valid_mask_trimmed] if len(iou_predictions.shape) > 1 else iou_predictions[valid_mask_trimmed]
                 valid_labels_raw = gt_labels[b][valid_mask]
                 
                 # Convert category_id to class index
@@ -337,14 +349,14 @@ class ModelEvaluator:
                 binary_masks = torch.zeros((0, pred_masks.shape[-2], pred_masks.shape[-1]), device=self.device)
                 valid_iou_preds = torch.zeros((0,), device=self.device)
                 valid_labels = torch.zeros((0,), dtype=torch.long, device=self.device)
-            
+
             predictions_list.append({
                 'masks': binary_masks,
                 'scores': valid_iou_preds,
                 'labels': valid_labels
             })
-            
-            # Process targets
+
+            # Process targets (gt_masks was NOT trimmed, so use the full valid_mask)
             if valid_mask.sum() > 0:
                 valid_gt_masks = gt_masks[b][valid_mask]
                 valid_labels_raw = gt_labels[b][valid_mask]

--- a/ml_engine/evaluation/metrics.py
+++ b/ml_engine/evaluation/metrics.py
@@ -265,7 +265,16 @@ class SegmentationMetrics:
                 self.total_fp += 1
         
         self.total_fn += len(tgt_masks) - len(matched_gt)
-    
+
+        # Unmatched GTs count as 0 IoU/Dice — standard mIoU penalizes missed detections.
+        # Without this, a model with 10% recall that segments perfectly reports mIoU=1.0.
+        for gt_idx in range(len(tgt_masks)):
+            if gt_idx not in matched_gt:
+                gt_label = tgt_labels[gt_idx].item()
+                if 0 <= gt_label < self.num_classes:
+                    self.class_ious[gt_label].append(0.0)
+                    self.class_dice[gt_label].append(0.0)
+
     def compute(self) -> Dict[str, Any]:
         """Compute all segmentation metrics."""
         per_class_iou = {}
@@ -336,7 +345,7 @@ class SimpleMetricsConverter:
             Dict with simple metrics for rookies
         """
         # Overall score is mAP@50 scaled to 0-100
-        overall_score = technical_metrics.get('mAP50') * 100
+        overall_score = technical_metrics.get('mAP50', 0.0) * 100
 
         # Grade based on overall score
         grade = self._get_grade(overall_score)

--- a/ml_engine/evaluation/report.py
+++ b/ml_engine/evaluation/report.py
@@ -260,6 +260,10 @@ class ModelReportGenerator:
         if report['model_type'] == 'segmentation':
             lines.append(f"Coverage Rate: {simple.get('coverage_rate', 0):.1f}%")
             lines.append(f"Quality Rate: {simple.get('quality_rate', 0):.1f}%")
+            if report.get('evaluation_mode') == 'oracle_gt_prompts':
+                lines.append("")
+                lines.append("NOTE: Evaluated with ground-truth box prompts (oracle mode).")
+                lines.append("      In production, prompts come from GroundingDINO — real mIoU will be lower.")
             lines.append("")
         
         # Technical metrics

--- a/ml_engine/models/teacher/grounding_dino_lora.py
+++ b/ml_engine/models/teacher/grounding_dino_lora.py
@@ -14,7 +14,7 @@ import logging
 import torch
 from torch import nn
 from ml_engine.training.peft_utils import (
-    verify_freezing, save_lora_adapters, apply_lora, load_lora_model
+    verify_freezing, save_lora_adapters, apply_lora
 )
 from groundingdino.util.slconfig import SLConfig
 from groundingdino.models import build_model
@@ -86,6 +86,10 @@ class GroundingDINOLoRA(nn.Module):
 
         self.lora_config = lora_config
         self.bert_model_path = bert_model_path
+        self._text_token_mask_cache: Optional[torch.Tensor] = None
+        self._text_token_mask_caption: Optional[str] = None
+        self._positive_map_cache: Optional[torch.Tensor] = None
+        self._positive_map_class_key: Optional[str] = None
 
         logger.info("Loading Grounding DINO from: %s", base_checkpoint)
         self.model = self._load_base_model(base_checkpoint)
@@ -304,14 +308,21 @@ class GroundingDINOLoRA(nn.Module):
         # Must use 'samples' parameter name to match original GroundingDINO signature
         outputs = self.model(samples=images, captions=captions)
         
-        # Add text_token_mask for loss computation (needed to filter -inf padding)
-        # Get tokenizer and tokenize captions to extract mask
-        base_model = self.model.base_model.model if hasattr(self.model, 'base_model') else self.model
-        tokenized = base_model.tokenizer(captions, padding='longest', return_tensors='pt')
-        text_token_mask = tokenized.attention_mask.bool()  # [B, num_valid_tokens]
-        
-        # Move to same device as outputs
-        text_token_mask = text_token_mask.to(outputs['pred_logits'].device)
+        # Add text_token_mask for loss computation (needed to filter -inf padding).
+        # All batch items share the same caption (class names don't change), so we
+        # tokenize once and cache — the mask is identical for every forward call.
+        assert captions is not None  # guaranteed: either passed in or built from class_names above
+        caption_key = captions[0]
+        if self._text_token_mask_cache is None or self._text_token_mask_caption != caption_key:
+            base_model = self.model.base_model.model if hasattr(self.model, 'base_model') else self.model
+            tokenized = base_model.tokenizer(captions[:1], padding='longest', return_tensors='pt')
+            self._text_token_mask_cache = tokenized.attention_mask.bool()  # [1, num_valid_tokens]
+            self._text_token_mask_caption = caption_key
+
+        # Expand cached mask to match current batch size and move to correct device
+        assert self._text_token_mask_cache is not None
+        batch_size = outputs['pred_logits'].shape[0]
+        text_token_mask = self._text_token_mask_cache.expand(batch_size, -1).to(outputs['pred_logits'].device)
         outputs['text_token_mask'] = text_token_mask
         
         if return_features and hasattr(self.model, 'get_features'):
@@ -363,21 +374,28 @@ class GroundingDINOLoRA(nn.Module):
         batch_size = pred_logits.shape[0]
         device = pred_logits.device
 
-        # Build positive_map for token -> class mapping (same for all batch items)
-        caption, cat2tokenspan = build_captions_and_token_span(class_names, force_lowercase=False)
-        tokenized = self.tokenizer(caption, padding="longest", return_tensors="pt").to(device)
-        token_span_per_class = []
-        for name in class_names:
-            if name not in cat2tokenspan:
-                raise ValueError(
-                    f"Class '{name}' not found in cat2tokenspan during predict()!\n"
-                    f"Available classes: {list(cat2tokenspan.keys())}\n"
-                    f"This indicates a mismatch between class_names and caption tokenization."
-                )
-            token_span_per_class.append(cat2tokenspan[name])
-        positive_map = create_positive_map_from_span(
-            tokenized, token_span_per_class, max_text_len=pred_logits.shape[-1]
-        ).to(device)  # [num_classes, num_tokens]
+        # Build positive_map for token -> class mapping (same for all batch items).
+        # class_names never change during evaluation, so cache after first build.
+        class_key = ",".join(class_names)
+        if self._positive_map_cache is None or self._positive_map_class_key != class_key:
+            caption, cat2tokenspan = build_captions_and_token_span(class_names, force_lowercase=False)
+            tokenized = self.tokenizer(caption, padding="longest", return_tensors="pt")
+            token_span_per_class = []
+            for name in class_names:
+                if name not in cat2tokenspan:
+                    raise ValueError(
+                        f"Class '{name}' not found in cat2tokenspan during predict()!\n"
+                        f"Available classes: {list(cat2tokenspan.keys())}\n"
+                        f"This indicates a mismatch between class_names and caption tokenization."
+                    )
+                token_span_per_class.append(cat2tokenspan[name])
+            self._positive_map_cache = create_positive_map_from_span(
+                tokenized, token_span_per_class, max_text_len=pred_logits.shape[-1]
+            )  # [num_classes, num_tokens]
+            self._positive_map_class_key = class_key
+
+        assert self._positive_map_cache is not None
+        positive_map = self._positive_map_cache.to(device)  # [num_classes, num_tokens]
 
         # Convert to per-image predictions
         results = []

--- a/ml_engine/models/teacher/sam_lora.py
+++ b/ml_engine/models/teacher/sam_lora.py
@@ -15,7 +15,7 @@ import torch
 from torch import nn
 from segment_anything import sam_hq_model_registry  # Use SAM-HQ
 from ml_engine.training.peft_utils import (
-    apply_lora, freeze_module, unfreeze_module, load_lora_model, verify_freezing
+    apply_lora, freeze_module, unfreeze_module, verify_freezing
 )
 
 logger = logging.getLogger(__name__)

--- a/ml_engine/training/__init__.py
+++ b/ml_engine/training/__init__.py
@@ -7,11 +7,9 @@ from .losses import SegmentationLoss, CombinedTeacherLoss, build_criterion
 from .peft_utils import (
     apply_lora,
     verify_freezing,
-    load_lora_model,
     save_lora_adapters,
     freeze_module,
     unfreeze_module,
-    partial_freeze_for_lora
 )
 
 # Lazy imports for heavy model-dependent modules
@@ -59,9 +57,7 @@ __all__ = [
     # LoRA utilities
     'apply_lora',
     'verify_freezing',
-    'load_lora_model',
     'save_lora_adapters',
     'freeze_module',
     'unfreeze_module',
-    'partial_freeze_for_lora'
 ]

--- a/ml_engine/training/__init__.py
+++ b/ml_engine/training/__init__.py
@@ -3,7 +3,7 @@
 # Core utilities (always available)
 from .training_manager import TrainingManager
 from .checkpoint_manager import CheckpointManager
-from .losses import SegmentationLoss, CombinedTeacherLoss, build_criterion
+from .losses import SegmentationLoss, build_criterion
 from .peft_utils import (
     apply_lora,
     verify_freezing,
@@ -52,7 +52,6 @@ __all__ = [
     'CheckpointManager',
     # Losses
     'SegmentationLoss',
-    'CombinedTeacherLoss',
     'build_criterion',
     # LoRA utilities
     'apply_lora',

--- a/ml_engine/training/dino_utils.py
+++ b/ml_engine/training/dino_utils.py
@@ -112,8 +112,8 @@ def build_detr_targets(
         if len(valid_boxes) > 0:
             if (valid_boxes < 0).any() or (valid_boxes > 1).any():
                 logger.warning(
-                    f"Batch {b}: boxes not normalized! "
-                    f"Range: [{valid_boxes.min():.3f}, {valid_boxes.max():.3f}]"
+                    "Batch %d: boxes not normalized! Range: [%.3f, %.3f]",
+                    b, valid_boxes.min(), valid_boxes.max()
                 )
         
         # Create token labels for each valid object using the positive map

--- a/ml_engine/training/losses.py
+++ b/ml_engine/training/losses.py
@@ -4,21 +4,17 @@ Loss functions for teacher model fine-tuning.
 This module provides loss functions for:
 - Grounding DINO: Detection loss (classification + box regression)
 - SAM: Segmentation loss (mask IoU + focal loss)
-- Combined losses for multi-task learning
 """
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from typing import Dict, Optional, Tuple, List
-import numpy as np
 
 from groundingdino.util.box_ops import (
     box_cxcywh_to_xyxy,
     generalized_box_iou,
 )
-from groundingdino.models.GroundingDINO.utils import sigmoid_focal_loss
-
 from scipy.optimize import linear_sum_assignment
 
 
@@ -45,33 +41,29 @@ class HungarianMatcher(nn.Module):
         cost_class: float = 1.0,
         cost_bbox: float = 5.0,
         cost_giou: float = 2.0,
-        use_focal: bool = True
     ):
         """
         Args:
             cost_class: Weight for classification cost in matching
             cost_bbox: Weight for L1 box cost in matching
             cost_giou: Weight for GIoU cost in matching
-            use_focal: Whether to use focal loss for classification cost
         """
         super().__init__()
         self.cost_class = cost_class
         self.cost_bbox = cost_bbox
         self.cost_giou = cost_giou
-        self.use_focal = use_focal
-        
+
         assert cost_class != 0 or cost_bbox != 0 or cost_giou != 0, "All costs can't be 0"
 
     @torch.no_grad()
     def forward(
-        self, 
-        outputs: Dict[str, torch.Tensor], 
-        targets: List[Dict[str, torch.Tensor]],
-        tokenizer=None
+        self,
+        outputs: Dict[str, torch.Tensor],
+        targets: List[Dict[str, torch.Tensor]]
     ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
         """
         Perform Hungarian matching with proper -inf filtering.
-        
+
         Args:
             outputs: Dict with:
                 - 'pred_logits': [B, N, num_tokens] token-level similarities
@@ -81,62 +73,58 @@ class HungarianMatcher(nn.Module):
                 - 'labels': [M] class labels (0-indexed)
                 - 'boxes': [M, 4] boxes in [cx, cy, w, h] format
                 - 'token_labels': [M, num_tokens] token-level targets
-            tokenizer: Optional tokenizer for token-to-class mapping
-        
+
         Returns:
             List of (pred_idx, tgt_idx) tuples, one per batch element
         """
         bs, num_queries = outputs["pred_logits"].shape[:2]
-        
+
         # Flatten batch dimension for cost computation
         out_logits = outputs["pred_logits"].flatten(0, 1)  # [B*N, num_tokens]
         out_bbox = outputs["pred_boxes"].flatten(0, 1)  # [B*N, 4]
 
         # Concatenate targets across batch
-        tgt_ids = torch.cat([v["labels"] for v in targets])  # [total_targets]
         tgt_bbox = torch.cat([v["boxes"] for v in targets])  # [total_targets, 4]
-        
+
         # Get token-level targets
         assert "token_labels" in targets[0], "token_labels required for matching!"
-        tgt_token_labels = torch.cat([v["token_labels"] for v in targets])  # [total_targets, num_tokens]
+        # [total_targets, num_tokens]
+        tgt_token_labels = torch.cat([v["token_labels"] for v in targets])
 
-        # Classification cost using focal loss
-        if self.use_focal:
-            # Filter valid token positions only
-            text_token_mask = outputs.get('text_token_mask', None)
-            if text_token_mask is not None:
-                # Create mask [B*N, num_tokens]
-                B, num_valid = text_token_mask.shape
-                num_tokens = out_logits.shape[-1]
-                text_mask = torch.zeros((B, num_tokens), dtype=torch.bool, device=out_logits.device)
-                text_mask[:, :num_valid] = text_token_mask
-                text_mask = text_mask.unsqueeze(1).repeat(1, num_queries, 1).flatten(0, 1)  # [B*N, num_tokens]
-            else:
-                # Fallback: use -inf detection
-                text_mask = ~torch.isinf(out_logits)
-            
-            # Only compute focal cost on valid positions
-            out_prob = out_logits.sigmoid()  # [B*N, num_tokens]
-            
-            alpha = 0.25
-            gamma = 2.0
-            neg_cost_class = (1 - alpha) * (out_prob ** gamma) * (-(1 - out_prob + 1e-8).log())
-            pos_cost_class = alpha * ((1 - out_prob) ** gamma) * (-(out_prob + 1e-8).log())
-            
-            # Mask out invalid positions (set cost to 0 for padded tokens)
-            neg_cost_class = neg_cost_class * text_mask.float()
-            pos_cost_class = pos_cost_class * text_mask.float()
-            
-            # Compute cost for each query-target pair
-            cost_class = []
-            for token_label in tgt_token_labels:
-                pos_cost = (pos_cost_class * token_label.unsqueeze(0)).sum(-1)  # [B*N]
-                neg_cost = (neg_cost_class * (1 - token_label.unsqueeze(0))).sum(-1)  # [B*N]
-                cost_class.append(pos_cost - neg_cost)
-            cost_class = torch.stack(cost_class, dim=1)  # [B*N, total_targets]
+        # Classification cost: token-level focal loss (sigmoid, not softmax).
+        # Grounding DINO uses multi-label token prediction — softmax is wrong here.
+        # Filter valid token positions only
+        text_token_mask = outputs.get('text_token_mask', None)
+        if text_token_mask is not None:
+            # Create mask [B*N, num_tokens]
+            B, num_valid = text_token_mask.shape
+            num_tokens = out_logits.shape[-1]
+            text_mask = torch.zeros((B, num_tokens), dtype=torch.bool, device=out_logits.device)
+            text_mask[:, :num_valid] = text_token_mask
+            text_mask = text_mask.unsqueeze(1).expand(-1, num_queries, -1).reshape(B * num_queries, -1)  # [B*N, num_tokens]
         else:
-            out_prob = out_logits.softmax(-1)
-            cost_class = -out_prob[:, tgt_ids]
+            # Fallback: use -inf detection
+            text_mask = ~torch.isinf(out_logits)
+
+        # Only compute focal cost on valid positions
+        out_prob = out_logits.sigmoid()  # [B*N, num_tokens]
+
+        alpha = 0.25
+        gamma = 2.0
+        neg_cost_class = (1 - alpha) * (out_prob ** gamma) * (-(1 - out_prob + 1e-8).log())
+        pos_cost_class = alpha * ((1 - out_prob) ** gamma) * (-(out_prob + 1e-8).log())
+
+        # Mask out invalid positions (set cost to 0 for padded tokens)
+        neg_cost_class = neg_cost_class * text_mask.float()
+        pos_cost_class = pos_cost_class * text_mask.float()
+
+        # Compute cost for each query-target pair via matmul
+        # tgt_token_labels: [total_targets, num_tokens]
+        # pos/neg_cost_class: [B*N, num_tokens]
+        cost_class = (
+            pos_cost_class @ tgt_token_labels.T
+            - neg_cost_class @ (1 - tgt_token_labels).T
+        )  # [B*N, total_targets]
 
         # L1 cost between boxes
         cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)  # [B*N, total_targets]
@@ -154,9 +142,9 @@ class HungarianMatcher(nn.Module):
         # Split by batch and compute Hungarian matching
         sizes = [len(v["boxes"]) for v in targets]
         indices = [linear_sum_assignment(c[i]) for i, c in enumerate(C.split(sizes, -1))]
-        
+
         # Return as list of (pred_idx, tgt_idx) tensors
-        return [(torch.as_tensor(i, dtype=torch.int64), torch.as_tensor(j, dtype=torch.int64)) 
+        return [(torch.as_tensor(i, dtype=torch.int64), torch.as_tensor(j, dtype=torch.int64))
                 for i, j in indices]
 
 
@@ -181,7 +169,7 @@ class GroundingDINOCriterion(nn.Module):
         num_classes: int,
         matcher: HungarianMatcher,
         weight_dict: Dict[str, float],
-        losses: List[str] = ['labels', 'boxes'],
+        losses: Optional[List[str]] = None,
         focal_alpha: float = 0.25,
         focal_gamma: float = 2.0
     ):
@@ -198,7 +186,7 @@ class GroundingDINOCriterion(nn.Module):
                     'loss_bbox_0': 5.0,
                     ...
                 }
-            losses: List of losses to compute ['labels', 'boxes']
+            losses: List of losses to compute. Defaults to ['labels', 'boxes'].
             focal_alpha: Alpha parameter for focal loss
             focal_gamma: Gamma parameter for focal loss
         """
@@ -206,7 +194,7 @@ class GroundingDINOCriterion(nn.Module):
         self.num_classes = num_classes
         self.matcher = matcher
         self.weight_dict = weight_dict
-        self.losses = losses
+        self.losses = list(losses) if losses is not None else ['labels', 'boxes']
         self.focal_alpha = focal_alpha
         self.focal_gamma = focal_gamma
 
@@ -248,28 +236,28 @@ class GroundingDINOCriterion(nn.Module):
         assert 'pred_logits' in outputs
         src_logits = outputs['pred_logits']  # [B, N, num_tokens]
         batch_size, num_queries, max_text_len = src_logits.shape
-        
-        # ===== CRITICAL FIX: Create target labels for ALL queries =====
-        # Default: all zeros (background/no-object)
+
+        # Create target labels for ALL queries
         target_labels = torch.zeros_like(src_logits)  # [B, N, max_text_len]
-        
+
         # Count matched and unmatched queries for avg_factor
         num_total_pos = 0  # Number of matched queries
         num_total_neg = 0  # Number of unmatched queries
-        
+
         # Only matched queries get their positive_map assigned
         assert "token_labels" in targets[0], "token_labels must be provided!"
         for batch_idx, (src_idx, tgt_idx) in enumerate(indices):
             if len(src_idx) > 0:
-                # src_idx: which queries are matched
-                # tgt_idx: which ground truth boxes they match to
+                # src_idx: queries are matched
+                # tgt_idx: ground truth boxes they match to
+                # fill-in a 256 length vector of token labels for each matched query
                 target_labels[batch_idx, src_idx] = targets[batch_idx]['token_labels'][tgt_idx]
                 num_total_pos += len(src_idx)
             num_total_neg += num_queries - len(src_idx)
-        
+
         # ===== Build text mask to filter padded tokens =====
         text_token_mask = outputs.get('text_token_mask', None)
-        
+
         if text_token_mask is not None:
             # Pad text_token_mask to max_text_len
             text_masks = torch.zeros((batch_size, max_text_len), dtype=torch.bool, device=src_logits.device)
@@ -279,18 +267,18 @@ class GroundingDINOCriterion(nn.Module):
         else:
             # Fallback: detect valid positions using -inf
             text_mask = ~torch.isinf(src_logits)
-        
+
         # ===== Filter padded tokens using masked_select =====
         src_logits_valid = torch.masked_select(src_logits, text_mask).contiguous()
         target_labels_valid = torch.masked_select(target_labels, text_mask).contiguous()
-        
+
         # ===== Compute focal loss following MMDetection's normalization =====
         # avg_factor = num_total_pos + num_total_neg * bg_cls_weight
         # bg_cls_weight is typically 0.1 in DETR/DINO
         bg_cls_weight = 0.1
         avg_factor = num_total_pos * 1.0 + num_total_neg * bg_cls_weight
         avg_factor = max(avg_factor, 1.0)  # Prevent division by zero
-        
+
         if src_logits_valid.numel() > 0:
             # Compute focal loss per element (no reduction)
             loss_ce = self._focal_loss(
@@ -302,20 +290,23 @@ class GroundingDINOCriterion(nn.Module):
             # Sum and normalize by avg_factor (MMDetection approach)
             loss_ce = loss_ce.sum() / avg_factor
         else:
-            loss_ce = torch.tensor(0.0, device=src_logits.device)
-        
+            loss_ce = torch.tensor(0.0, device=src_logits.device, requires_grad=True)
+
         losses = {'loss_ce': loss_ce}
 
         if log:
-            # Compute classification accuracy on valid positions
-            if src_logits_valid.numel() > 0:
-                pred_binary = (src_logits_valid.sigmoid() > 0.5).float()
-                losses['class_error'] = 100 - (pred_binary == target_labels_valid).float().mean() * 100
+            # Recall on positive tokens — "what fraction of object tokens did we fire on?"
+            # Token-level accuracy is useless here: with ~6 positive tokens out of ~6300,
+            # a model that always predicts 0 scores 99.9% accuracy.
+            pos_mask = target_labels_valid > 0.5
+            if pos_mask.any():
+                pos_recall = (src_logits_valid[pos_mask].sigmoid() > 0.5).float().mean() * 100
+                losses['class_error'] = 100 - pos_recall
             else:
                 losses['class_error'] = torch.tensor(100.0, device=src_logits.device)
 
         return losses
-    
+
     def _focal_loss(
         self,
         pred: torch.Tensor,
@@ -339,17 +330,17 @@ class GroundingDINOCriterion(nn.Module):
         """
         pred_sigmoid = pred.sigmoid()
         target = target.type_as(pred)
-        
+
         # pt = p if target=1, else (1-p)
         # Actually, pt here denotes (1 - pt) in the Focal Loss paper
         pt = (1 - pred_sigmoid) * target + pred_sigmoid * (1 - target)
-        
+
         # Focal weight: alpha * (1-pt)^gamma for positive, (1-alpha) * pt^gamma for negative
         focal_weight = (alpha * target + (1 - alpha) * (1 - target)) * pt.pow(gamma)
-        
+
         # Binary cross entropy
         loss = F.binary_cross_entropy_with_logits(pred, target, reduction='none') * focal_weight
-        
+
         return loss
 
     def loss_boxes(
@@ -400,12 +391,6 @@ class GroundingDINOCriterion(nn.Module):
         src_idx = torch.cat([src for (src, _) in indices])
         return batch_idx, src_idx
 
-    def _get_tgt_permutation_idx(self, indices):
-        """Permute targets following matched indices."""
-        batch_idx = torch.cat([torch.full_like(tgt, i) for i, (_, tgt) in enumerate(indices)])
-        tgt_idx = torch.cat([tgt for (_, tgt) in indices])
-        return batch_idx, tgt_idx
-
     def get_loss(
         self,
         loss: str,
@@ -446,7 +431,7 @@ class GroundingDINOCriterion(nn.Module):
             Dict with all loss components
         """
         # Separate auxiliary outputs
-        outputs_without_aux = {k: v for k, v in outputs.items() 
+        outputs_without_aux = {k: v for k, v in outputs.items()
                                if k not in ['aux_outputs', 'enc_outputs']}
 
         # 1. Match final layer predictions to targets
@@ -454,7 +439,7 @@ class GroundingDINOCriterion(nn.Module):
 
         # Compute number of boxes for normalization
         num_boxes = sum(len(t["labels"]) for t in targets)
-        num_boxes = torch.as_tensor([num_boxes], dtype=torch.float, 
+        num_boxes = torch.as_tensor([num_boxes], dtype=torch.float,
                                    device=next(iter(outputs.values())).device)
         num_boxes = torch.clamp(num_boxes, min=1).item()
 
@@ -485,11 +470,14 @@ class GroundingDINOCriterion(nn.Module):
             text_token_mask = outputs.get('text_token_mask', None)
             if text_token_mask is not None:
                 enc_outputs = {**enc_outputs, 'text_token_mask': text_token_mask}
-            # For encoder, use binary targets (objectness)
-            # Keep token_labels from original targets for matching
-            bin_targets = [{'labels': torch.zeros_like(t['labels']), 
+            # For encoder, use binary objectness targets: "something is here, class unknown".
+            # token_labels are set to all-ones so every valid token position is activated
+            # uniformly — loss_labels will mask out padding via text_token_mask.
+            # Using class-specific token_labels here would contradict the zeroed class labels
+            # and train the encoder with the same signal as the final decoder layer.
+            bin_targets = [{'labels': torch.zeros_like(t['labels']),
                            'boxes': t['boxes'],
-                           'token_labels': t['token_labels']} for t in targets]
+                           'token_labels': torch.ones_like(t['token_labels'])} for t in targets]
             indices = self.matcher(enc_outputs, bin_targets)
             for loss in self.losses:
                 kwargs = {'log': False} if loss == 'labels' else {}
@@ -523,7 +511,6 @@ def build_criterion(
         cost_class=1.0,
         cost_bbox=5.0,
         cost_giou=2.0,
-        use_focal=True
     )
 
     # Loss weights from paper
@@ -642,13 +629,13 @@ class SegmentationLoss(nn.Module):
                 # IoU loss
                 loss_iou = self.iou_loss(valid_pred, valid_target)
             else:
-                loss_focal = torch.tensor(0.0, device=pred_masks.device)
-                loss_dice = torch.tensor(0.0, device=pred_masks.device)
-                loss_iou = torch.tensor(0.0, device=pred_masks.device)
+                loss_focal = torch.tensor(0.0, device=pred_masks.device, requires_grad=True)
+                loss_dice = torch.tensor(0.0, device=pred_masks.device, requires_grad=True)
+                loss_iou = torch.tensor(0.0, device=pred_masks.device, requires_grad=True)
         else:
-            loss_focal = torch.tensor(0.0, device=pred_masks.device)
-            loss_dice = torch.tensor(0.0, device=pred_masks.device)
-            loss_iou = torch.tensor(0.0, device=pred_masks.device)
+            loss_focal = torch.tensor(0.0, device=pred_masks.device, requires_grad=True)
+            loss_dice = torch.tensor(0.0, device=pred_masks.device, requires_grad=True)
+            loss_iou = torch.tensor(0.0, device=pred_masks.device, requires_grad=True)
         
         # Total loss
         total_loss = (
@@ -673,11 +660,11 @@ class SegmentationLoss(nn.Module):
         Sigmoid focal loss for binary masks.
         
         Args:
-            inputs: Predicted masks (logits) [B, N, H, W]
-            targets: Target masks (binary) [B, N, H, W]
-        
+            inputs: Predicted masks (logits) [num_valid, H*W] — already flattened spatially
+            targets: Target masks (binary) [num_valid, H*W]
+
         Returns:
-            Focal loss value
+            Mean focal loss across all valid masks
         """
         prob = inputs.sigmoid()
         ce_loss = F.binary_cross_entropy_with_logits(inputs, targets, reduction='none')
@@ -697,27 +684,27 @@ class SegmentationLoss(nn.Module):
         smooth: float = 1.0
     ) -> torch.Tensor:
         """
-        Dice loss for segmentation.
-        
+        Dice loss for segmentation, computed per mask and averaged.
+
+        Note: called from forward() with pre-selected valid masks.
+
         Args:
-            inputs: Predicted masks (logits) [B, N, H, W]
-            targets: Target masks (binary) [B, N, H, W]
+            inputs: Predicted masks (logits) [num_valid, H*W] — already flattened spatially
+            targets: Target masks (binary) [num_valid, H*W]
             smooth: Smoothing factor
-        
+
         Returns:
-            Dice loss value
+            Mean dice loss across all valid masks
         """
-        inputs = inputs.sigmoid()
-        
-        # Flatten
-        inputs = inputs.view(-1)
-        targets = targets.view(-1)
-        
-        intersection = (inputs * targets).sum()
-        dice = (2. * intersection + smooth) / (inputs.sum() + targets.sum() + smooth)
-        
-        return 1 - dice
-    
+        inputs = inputs.sigmoid()  # [num_valid, H*W]
+
+        # Sum over spatial dimension (dim=1) to get per-mask intersection/area
+        intersection = (inputs * targets).sum(dim=1)        # [num_valid]
+        dice = (2. * intersection + smooth) / (
+            inputs.sum(dim=1) + targets.sum(dim=1) + smooth  # [num_valid]
+        )
+        return (1 - dice).mean()
+
     def iou_loss(
         self,
         inputs: torch.Tensor,
@@ -725,92 +712,22 @@ class SegmentationLoss(nn.Module):
         smooth: float = 1.0
     ) -> torch.Tensor:
         """
-        IoU loss for segmentation.
-        
+        IoU loss for segmentation, computed per mask and averaged.
+
+        Note: called from forward() with pre-selected valid masks.
+
         Args:
-            inputs: Predicted masks (logits) [B, N, H, W]
-            targets: Target masks (binary) [B, N, H, W]
+            inputs: Predicted masks (logits) [num_valid, H*W] — already flattened spatially
+            targets: Target masks (binary) [num_valid, H*W]
             smooth: Smoothing factor
-        
-        Returns:
-            IoU loss value
-        """
-        inputs = inputs.sigmoid()
-        
-        # Flatten
-        inputs = inputs.view(-1)
-        targets = targets.view(-1)
-        
-        intersection = (inputs * targets).sum()
-        union = inputs.sum() + targets.sum() - intersection
-        iou = (intersection + smooth) / (union + smooth)
-        
-        return 1 - iou
 
-
-class CombinedTeacherLoss(nn.Module):
-    """
-    Combined loss for multi-task teacher training.
-    
-    When training both detection and segmentation together.
-    
-    Example:
-        >>> criterion = CombinedTeacherLoss(num_classes=3)
-        >>> loss_dict = criterion(predictions, targets)
-    """
-    
-    def __init__(
-        self,
-        num_classes: int,
-        task_weights: Optional[Dict[str, float]] = None
-    ):
-        """
-        Args:
-            num_classes: Number of classes
-            task_weights: Weights for each task (detection, segmentation)
-        """
-        super().__init__()
-        
-        self.detection_loss = DetectionLoss(num_classes)
-        self.segmentation_loss = SegmentationLoss()
-        
-        if task_weights is None:
-            task_weights = {'detection': 1.0, 'segmentation': 1.0}
-        self.task_weights = task_weights
-    
-    def forward(
-        self,
-        predictions: Dict[str, torch.Tensor],
-        targets: Dict[str, torch.Tensor]
-    ) -> Dict[str, torch.Tensor]:
-        """
-        Compute combined loss.
-        
-        Args:
-            predictions: Dict with detection and segmentation predictions
-            targets: Dict with detection and segmentation targets
-        
         Returns:
-            Dict with all loss components
+            Mean IoU loss across all valid masks
         """
-        loss_dict = {}
-        total_loss = 0
-        
-        # Detection loss
-        if 'pred_logits' in predictions and 'labels' in targets:
-            det_losses = self.detection_loss(predictions, targets)
-            for k, v in det_losses.items():
-                if k != 'loss':
-                    loss_dict[f'det_{k}'] = v
-            total_loss += self.task_weights['detection'] * det_losses['loss']
-        
-        # Segmentation loss
-        if 'pred_masks' in predictions and 'masks' in targets:
-            seg_losses = self.segmentation_loss(predictions, targets)
-            for k, v in seg_losses.items():
-                if k != 'loss':
-                    loss_dict[f'seg_{k}'] = v
-            total_loss += self.task_weights['segmentation'] * seg_losses['loss']
-        
-        loss_dict['loss'] = total_loss
-        return loss_dict
+        inputs = inputs.sigmoid()  # [num_valid, H*W]
+
+        # Per-mask intersection and union
+        intersection = (inputs * targets).sum(dim=1)        # [num_valid]
+        union = inputs.sum(dim=1) + targets.sum(dim=1) - intersection  # [num_valid]
+        iou = (intersection + smooth) / (union + smooth)    # [num_valid]
+        return (1 - iou).mean()

--- a/ml_engine/training/model_trainers/base.py
+++ b/ml_engine/training/model_trainers/base.py
@@ -96,7 +96,6 @@ class BaseModelTrainer(ABC):
             model=self.model,
             optimizer=self.optimizer,
             config_path=str(DEFAULT_CONFIGS_DIR / 'training_dynamics.yaml'),
-            scheduler=self.scheduler,
             config_overrides=config.get('training_dynamics'),
         )
 
@@ -178,14 +177,15 @@ class BaseModelTrainer(ABC):
     def train_batch(self, batch: Dict[str, Any]) -> Dict[str, float]:
         """
         Execute one training step.
-        
+
         Args:
             batch: Batch from dataloader
-        
+
         Returns:
             Dict of loss values (float)
         """
-        self.model.train()
+        # model.train() is called inside training_manager.training_step() so
+        # that BN re-freeze (if configured) happens atomically with the mode switch.
 
         def _compute_loss(batch):
             return self.compute_loss(batch)
@@ -226,6 +226,11 @@ class BaseModelTrainer(ABC):
                 result[key] = value
 
         return result
+
+    def step_scheduler(self) -> None:
+        """Step the LR scheduler. Called once per epoch by Trainer."""
+        if self.scheduler is not None:
+            self.scheduler.step()
 
     def save_checkpoint(self, epoch: int, metrics: Dict[str, float]) -> bool:
         """

--- a/ml_engine/training/model_trainers/grounding_dino.py
+++ b/ml_engine/training/model_trainers/grounding_dino.py
@@ -102,7 +102,7 @@ class GroundingDINOTrainer(BaseModelTrainer):
         num_classes = self.dataset_info['num_classes']
         
         # Get number of decoder layers from model architecture
-        base_model = self.model.model.model  # Unwrap PEFT wrapper
+        base_model = self.model.model.base_model.model if hasattr(self.model.model, 'base_model') else self.model.model
         num_decoder_layers = base_model.transformer.decoder.num_layers
         
         criterion = build_criterion(
@@ -112,8 +112,8 @@ class GroundingDINOTrainer(BaseModelTrainer):
             focal_gamma=2.0
         )
         
-        logger.info(f"  Criterion: Hungarian matching with {num_decoder_layers} decoder layers")
-        logger.info(f"  Num classes: {num_classes}")
+        logger.info("  Criterion: Hungarian matching with %d decoder layers", num_decoder_layers)
+        logger.info("  Num classes: %d", num_classes)
         
         return criterion
     
@@ -179,22 +179,20 @@ class GroundingDINOTrainer(BaseModelTrainer):
         # Compute loss with Hungarian matching
         loss_dict = self.criterion(outputs, targets)
         
-        # Check for NaN
-        for k, v in loss_dict.items():
-            if torch.isnan(v).any():
-                logger.error(f"NaN detected in {k}: {v}")
-        
         # Compute total weighted loss
         total_loss = sum(
             loss_dict[k] * self.criterion.weight_dict[k]
             for k in loss_dict.keys()
             if k in self.criterion.weight_dict
         )
-        
+
         if torch.isnan(total_loss):
-            logger.error("NaN in total_loss!")
-            logger.error(f"Loss components: {loss_dict}")
-            logger.error(f"Valid objects: {total_valid_objs}")
+            logger.warning(
+                "NaN in total_loss, skipping batch. valid_objs=%d, components=%s",
+                total_valid_objs,
+                {k: v.item() for k, v in loss_dict.items() if k in self.criterion.weight_dict}
+            )
+            return {'loss': torch.tensor(0.0, device=self.device, requires_grad=True)}
         
         # Return dict with total loss and components
         result = {'loss': total_loss, 'total_loss': total_loss.detach()}

--- a/ml_engine/training/model_trainers/sam.py
+++ b/ml_engine/training/model_trainers/sam.py
@@ -95,10 +95,47 @@ class SAMTrainer(BaseModelTrainer):
             mask_decoder_mode=mask_decoder_mode
         )
         
-        logger.info(f"  Modes: encoder={image_encoder_mode}, prompt={prompt_encoder_mode}, decoder={mask_decoder_mode}")
+        logger.info("  Modes: encoder=%s, prompt=%s, decoder=%s",
+                    image_encoder_mode, prompt_encoder_mode, mask_decoder_mode)
         
         return model
     
+    def _create_optimizer(self) -> torch.optim.Optimizer:
+        """
+        Create AdamW with differential LR: mask decoder at a lower rate than LoRA adapters.
+
+        mask_decoder_mode='full' means all mask-decoder weights are trainable, so they
+        need a lower LR to avoid overwriting pretrained representations. LoRA adapters
+        start from zero and can tolerate the full base LR.
+        """
+        lr = self.config.get('learning_rate', 1e-4)
+        weight_decay = self.config.get('weight_decay', 1e-4)
+        multiplier = self.config.get('mask_decoder_lr_multiplier', 1.0)
+        mask_decoder_lr = lr * multiplier
+
+        mask_decoder_params = []
+        lora_params = []
+        for name, param in self.model.named_parameters():
+            if not param.requires_grad:
+                continue
+            if 'mask_decoder' in name:
+                mask_decoder_params.append(param)
+            else:
+                lora_params.append(param)
+
+        param_groups = []
+        if lora_params:
+            param_groups.append({'params': lora_params, 'lr': lr, 'name': 'lora'})
+        if mask_decoder_params:
+            param_groups.append({'params': mask_decoder_params, 'lr': mask_decoder_lr, 'name': 'mask_decoder'})
+
+        optimizer = torch.optim.AdamW(param_groups, weight_decay=weight_decay)
+        logger.info(
+            "  Optimizer: AdamW — lora %d params (lr=%s), mask_decoder %d params (lr=%s)",
+            len(lora_params), lr, len(mask_decoder_params), mask_decoder_lr
+        )
+        return optimizer
+
     def _create_criterion(self) -> nn.Module:
         """Create segmentation loss (focal + dice + IoU)."""
         criterion = SegmentationLoss()
@@ -125,18 +162,27 @@ class SAMTrainer(BaseModelTrainer):
         boxes = sam_data['boxes'].to(self.device)
         masks = sam_data['masks'].to(self.device)
         labels = sam_data['labels'].to(self.device)
-        
-        # Create validity mask
-        valid_mask = (labels != -1)
-        
+
+        # Create validity mask: collate_fn always puts valid objects first,
+        # so valid_mask is True at indices 0..n_valid-1 per image.
+        valid_mask = (labels != -1)  # [B, max_objs]
+
         # Check for valid data
         if not valid_mask.any():
             logger.warning("Batch has no valid objects! Skipping...")
             return {'loss': torch.tensor(0.0, device=self.device, requires_grad=True)}
-        
+
+        # Trim to max_valid: avoids running the mask decoder on padding entries.
+        # With max_objs=10 and 3 real objects, this cuts 7 wasted decoder calls per image.
+        max_valid = int(valid_mask.sum(dim=1).max().item())
+        max_valid = max(max_valid, 1)
+        boxes = boxes[:, :max_valid, :]   # [B, max_valid, 4]
+        masks = masks[:, :max_valid, :]   # [B, max_valid, H, W]
+        valid_mask = valid_mask[:, :max_valid]  # [B, max_valid]
+
         # Forward pass (boxes already in correct xyxy format from SAM preprocessing)
         outputs = self.model(images, box_prompts=boxes)
-        
+
         # Prepare targets
         targets = {
             'masks': masks,

--- a/ml_engine/training/peft_utils.py
+++ b/ml_engine/training/peft_utils.py
@@ -4,7 +4,6 @@ PEFT (Parameter-Efficient Fine-Tuning) utilities for LoRA integration.
 This module provides utilities for:
 - Applying LoRA to models
 - Verifying freezing status
-- Computing trainable parameter statistics
 - Loading and saving LoRA adapters
 """
 
@@ -12,7 +11,7 @@ import os
 import logging
 import torch
 from torch import nn
-from peft import LoraConfig, get_peft_model, PeftModel
+from peft import LoraConfig, get_peft_model
 from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -25,10 +24,10 @@ def apply_lora(
 ) -> nn.Module:
     """
     Apply LoRA to a model.
-    
+
     This automatically freezes all base model parameters and adds
     trainable LoRA adapters to specified modules.
-    
+
     Args:
         model: Base model to apply LoRA to
         lora_config: LoRA configuration dictionary with keys:
@@ -37,10 +36,10 @@ def apply_lora(
             - lora_dropout: Dropout probability
             - target_modules: List of module names to apply LoRA
         target_modules: Optional override for target modules
-    
+
     Returns:
         Model with LoRA adapters applied
-    
+
     Example:
         >>> model = load_grounding_dino()
         >>> lora_config = {
@@ -78,32 +77,37 @@ def apply_lora(
 def verify_freezing(model: nn.Module, strict: bool = True) -> Dict[str, int]:
     """
     Verify that base model is frozen and only LoRA adapters are trainable.
-    
+
     Args:
         model: Model to verify
         strict: If True, raises error if non-LoRA parameters are trainable.
-                If False, only logs warnings (use when you intentionally unfreeze
-                some parameters like prediction heads).
-    
+                If False, only logs warnings for non-LoRA trainable parameters
+                (use when you intentionally unfreeze some parameters like
+                prediction heads).
+                Note: A frozen LoRA parameter always raises regardless of strict,
+                as this indicates a misconfiguration that would prevent training.
+
     Returns:
         Dictionary with parameter statistics:
             - frozen_params: Number of frozen parameters
             - trainable_params: Number of trainable parameters
             - lora_params: Number of trainable LoRA parameters
+            - total_params: Total parameter count
             - trainable_ratio: Percentage of trainable parameters
-    
+
     Raises:
-        AssertionError: If strict=True and non-LoRA parameters are trainable
-    
+        AssertionError: If strict=True and non-LoRA parameters are trainable,
+                        or if any LoRA parameter is frozen (regardless of strict).
+
     Example:
         >>> # Strict mode (LoRA-only training)
         >>> model = apply_lora(base_model, lora_config)
         >>> stats = verify_freezing(model, strict=True)
-        >>> 
+        >>>
         >>> # Non-strict mode (LoRA + prediction heads)
         >>> model = apply_lora(base_model, lora_config)
         >>> unfreeze_prediction_heads(model)
-        >>> stats = verify_freezing(model, strict=False)  # Won't raise error
+        >>> stats = verify_freezing(model, strict=False)  # Won't raise for unfrozen heads
     """
     frozen_params = 0
     trainable_params = 0
@@ -123,16 +127,17 @@ def verify_freezing(model: nn.Module, strict: bool = True) -> Dict[str, int]:
                 non_lora_trainable.append(name)
                 if strict:
                     raise AssertionError(
-                        f"❌ Non-LoRA param is trainable: {name}\n"
+                        f"Non-LoRA param is trainable: {name}\n"
                         f"This defeats the purpose of LoRA! Only LoRA adapters should be trainable."
                     )
         else:
             frozen_params += param_count
 
-            # Check if LoRA parameter is frozen
+            # A frozen LoRA parameter is always a misconfiguration — it would
+            # silently prevent the adapter from training regardless of strict mode.
             if 'lora' in name.lower():
                 raise AssertionError(
-                    f"❌ LoRA param is frozen: {name}\n"
+                    f"LoRA param is frozen: {name}\n"
                     f"LoRA adapters should be trainable!"
                 )
 
@@ -150,14 +155,14 @@ def verify_freezing(model: nn.Module, strict: bool = True) -> Dict[str, int]:
     logger.info("=" * 60)
     logger.info("LoRA Freezing Verification")
     logger.info("=" * 60)
-    logger.info(" Frozen parameters:    %s (%sM)", frozen_params, frozen_params/1e6)
-    logger.info(" Trainable parameters: %s (%sM)", trainable_params, trainable_params/1e6)
-    logger.info(" LoRA parameters:      %s (%sM)", lora_params, lora_params/1e6)
+    logger.info(" Frozen parameters:    %s (%sM)", frozen_params, frozen_params / 1e6)
+    logger.info(" Trainable parameters: %s (%sM)", trainable_params, trainable_params / 1e6)
+    logger.info(" LoRA parameters:      %s (%sM)", lora_params, lora_params / 1e6)
     logger.info(" Trainable ratio:      %s%%", trainable_ratio)
     logger.info("=" * 60)
 
     if trainable_ratio > 5.0:
-        msg = " Warning: Trainable ratio (%s%%) is high for LoRA! Expected < 5%%", trainable_ratio
+        msg = " Warning: Trainable ratio (%.1f%%) is high for LoRA! Expected < 5%%" % trainable_ratio
         if strict:
             raise AssertionError(msg)
         logger.warning(msg)
@@ -168,67 +173,6 @@ def verify_freezing(model: nn.Module, strict: bool = True) -> Dict[str, int]:
     return stats
 
 
-def get_trainable_parameters_summary(model: nn.Module) -> str:
-    """
-    Get a formatted summary of trainable parameters.
-    
-    Args:
-        model: Model to summarize
-    
-    Returns:
-        Formatted string with parameter summary
-    """
-    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
-    total = sum(p.numel() for p in model.parameters())
-    ratio = 100 * trainable / total if total > 0 else 0
-
-    return (
-        f"Trainable params: {trainable:,} || "
-        f"All params: {total:,} || "
-        f"Trainable%: {ratio:.2f}%"
-    )
-
-
-def load_lora_model(
-    base_model: nn.Module,
-    lora_adapter_path: str,
-    merge: bool = False
-) -> nn.Module:
-    """
-    Load a LoRA-adapted model from base model and adapter weights.
-    
-    Args:
-        base_model: Base pretrained model
-        lora_adapter_path: Path to LoRA adapter directory
-        merge: If True, merge adapter into base model for faster inference
-    
-    Returns:
-        Model with LoRA adapters loaded
-    
-    Example:
-        >>> base_model = load_grounding_dino('pretrained/groundingdino.pth')
-        >>> model = load_lora_model(
-        >>>     base_model,
-        >>>     lora_adapter_path='experiments/exp1/teachers/dino_lora/',
-        >>>     merge=True  # For distillation
-        >>> )
-    """
-    logger.info(f"Loading LoRA adapters from: {lora_adapter_path}")
-    
-    # Load LoRA adapters
-    model = PeftModel.from_pretrained(base_model, lora_adapter_path)
-    
-    logger.info("✓ LoRA adapters loaded successfully")
-    
-    # Merge if requested
-    if merge:
-        logger.info("Merging LoRA adapters into base model...")
-        model = model.merge_and_unload()
-        logger.info("✓ LoRA adapters merged. Model is now a single fine-tuned model.")
-    
-    return model
-
-
 def save_lora_adapters(
     model: nn.Module,
     output_dir: str,
@@ -236,12 +180,15 @@ def save_lora_adapters(
 ) -> None:
     """
     Save only LoRA adapters (not the full model).
-    
+
     Args:
-        model: Model with LoRA adapters
+        model: Model with LoRA adapters (must be a PEFT model with save_pretrained)
         output_dir: Directory to save adapters
         safe_serialization: Use safe tensors format
-    
+
+    Raises:
+        ValueError: If model is not a PEFT model (no save_pretrained method)
+
     Example:
         >>> model = apply_lora(base_model, lora_config)
         >>> # ... training ...
@@ -254,19 +201,21 @@ def save_lora_adapters(
             output_dir,
             safe_serialization=safe_serialization
         )
-        logger.info("✓ Saved LoRA adapters to: %s", output_dir)
+        logger.info("Saved LoRA adapters to: %s", output_dir)
     else:
-        logger.warning("Model does not have save_pretrained method. Saving full state dict.")
-        torch.save(model.state_dict(), os.path.join(output_dir, 'adapter_model.bin'))
+        raise ValueError(
+            "Model has no save_pretrained method — is it a PEFT model? "
+            "Got: %s. Apply LoRA via apply_lora() before saving." % type(model).__name__
+        )
 
 
 def freeze_module(module: nn.Module) -> None:
     """
     Freeze all parameters in a module.
-    
+
     Args:
         module: Module to freeze
-    
+
     Example:
         >>> # Freeze image encoder
         >>> freeze_module(model.image_encoder)
@@ -278,140 +227,9 @@ def freeze_module(module: nn.Module) -> None:
 def unfreeze_module(module: nn.Module) -> None:
     """
     Unfreeze all parameters in a module.
-    
+
     Args:
         module: Module to unfreeze
     """
     for param in module.parameters():
         param.requires_grad = True
-
-
-def partial_freeze_for_lora(
-    model: nn.Module,
-    freeze_modules: List[str],
-    lora_config: Dict,
-    lora_modules: Optional[List[str]] = None
-) -> nn.Module:
-    """
-    Apply partial freeze strategy + LoRA.
-    
-    This is the recommended approach:
-    1. Freeze specified modules (e.g., image encoder)
-    2. Apply LoRA to remaining modules (e.g., decoder)
-    
-    Args:
-        model: Base model
-        freeze_modules: List of module names to freeze
-        lora_config: LoRA configuration
-        lora_modules: Optional list of module names where LoRA should be applied.
-                      Only used with full-path target_modules (containing dots).
-                      Simple names like 'q_proj' are matched by PEFT directly.
-    
-    Returns:
-        Model with partial freeze + LoRA applied
-    
-    Example:
-        >>> # For SAM
-        >>> model = load_sam()
-        >>> model = partial_freeze_for_lora(
-        >>>     model,
-        >>>     freeze_modules=['image_encoder', 'prompt_encoder'],
-        >>>     lora_config=sam_lora_config,
-        >>>     lora_modules=['mask_decoder']
-        >>> )
-    """
-    # Freeze specified modules
-    for name, module in model.named_children():
-        if name in freeze_modules:
-            freeze_module(module)
-            logger.info("  Frozen module: %s", name)
-    
-    # Apply LoRA
-    # Note: lora_modules filtering is only needed for full-path target_modules.
-    # Simple names like 'q_proj' are matched by PEFT directly via substring matching.
-    # Since we've already frozen the modules we don't want, PEFT will only
-    # create LoRA adapters for matching modules in non-frozen parts.
-    if lora_modules:
-        lora_config = lora_config.copy()
-        target_modules = lora_config.get('target_modules', [])
-
-        # Only filter if target_modules use full paths (contain dots)
-        has_full_paths = any('.' in tm for tm in target_modules)
-        if has_full_paths:
-            lora_config['target_modules'] = [
-                tm for tm in target_modules
-                if any(lm in tm for lm in lora_modules)
-            ]
-
-    model = apply_lora(model, lora_config)
-
-    return model
-
-
-def count_lora_parameters(model: nn.Module) -> Dict[str, int]:
-    """
-    Count LoRA-specific parameters.
-    
-    Args:
-        model: Model with LoRA
-    
-    Returns:
-        Dictionary with LoRA parameter counts
-    """
-    lora_a_params = 0
-    lora_b_params = 0
-    other_lora_params = 0
-
-    for name, param in model.named_parameters():
-        if 'lora' in name.lower():
-            if 'lora_a' in name.lower():
-                lora_a_params += param.numel()
-            elif 'lora_b' in name.lower():
-                lora_b_params += param.numel()
-            else:
-                other_lora_params += param.numel()
-
-    total_lora = lora_a_params + lora_b_params + other_lora_params
-
-    return {
-        'lora_a_params': lora_a_params,
-        'lora_b_params': lora_b_params,
-        'other_lora_params': other_lora_params,
-        'total_lora_params': total_lora
-    }
-
-
-def get_lora_rank(model: nn.Module) -> Optional[int]:
-    """
-    Get LoRA rank from model.
-    
-    Args:
-        model: Model with LoRA
-    
-    Returns:
-        LoRA rank if found, else None
-    """
-    for name, param in model.named_parameters():
-        if 'lora_a' in name.lower():
-            # LoRA A has shape [r, input_dim]
-            return param.shape[0]
-    return None
-
-
-def enable_lora_dropout(model: nn.Module, dropout_rate: float = 0.1) -> None:
-    """
-    Enable dropout in LoRA layers during training.
-    
-    Args:
-        model: Model with LoRA
-        dropout_rate: Dropout rate to set
-    """
-    for name, module in model.named_modules():
-        if 'lora' in name.lower() and isinstance(module, nn.Dropout):
-            module.p = dropout_rate
-            logger.info("Set dropout rate to %s for: %s", dropout_rate, name)
-
-
-def disable_lora_dropout(model: nn.Module) -> None:
-    """Disable dropout in LoRA layers for inference."""
-    enable_lora_dropout(model, dropout_rate=0.0)

--- a/ml_engine/training/trainer.py
+++ b/ml_engine/training/trainer.py
@@ -11,6 +11,7 @@ It coordinates:
 - Test evaluation and export
 """
 
+import json
 import logging
 from collections import defaultdict
 from pathlib import Path
@@ -265,6 +266,7 @@ class Trainer:
                 all_metrics = {**train_metrics, **val_metrics, 'epoch': epoch}
 
                 # Save checkpoints and log
+                stop_training = False
                 for name, trainer in self.trainers.items():
                     trainer.save_checkpoint(epoch, all_metrics)
                     trainer.log_metrics(train_metrics, epoch, prefix='train')
@@ -273,7 +275,11 @@ class Trainer:
 
                     if trainer.should_stop:
                         logger.info("Early stopping triggered for %s", name)
-                        break
+                        stop_training = True
+                        break  # exits inner trainer loop
+
+                if stop_training:
+                    break  # exits epoch loop — finalization still runs in try block
 
                 # Report progress
                 if self.progress_callback:
@@ -317,30 +323,36 @@ class Trainer:
                 losses = trainer.train_batch(batch)
                 for k, v in losses.items():
                     metrics_acc[f"{name}_{k}"].append(v)
-            
+
             # Update progress bar
             postfix = {}
             for k, v in metrics_acc.items():
                 if 'total_loss' in k:
                     postfix[k] = f"{v[-1]:.4f}"
             pbar.set_postfix(postfix)
-            
+
             # Report step progress
             if self.progress_callback and total_steps > 0:
                 report_interval = max(1, total_steps // 10)
                 if step % report_interval == 0:
                     self.progress_callback({
-                        'current_epoch': epoch,
+                        'current_epoch': epoch + 1,
                         'total_epochs': self.config.get('epochs', 50),
                         'current_step': step + 1,
                         'total_steps': total_steps,
                         'message': f"Epoch {epoch + 1}, Step {step + 1}/{total_steps}"
                     })
         
+        # Step LR schedulers once per epoch (correct granularity for CosineAnnealingWarmRestarts
+        # with T_0 set in epochs). Stepping per optimizer-update inside TrainingManager would
+        # compress the schedule by a factor of accumulation_steps * batches_per_epoch.
+        for trainer in self.trainers.values():
+            trainer.step_scheduler()
+
         # Average metrics
         train_metrics = {f'train_{k}': sum(v) / len(v) for k, v in metrics_acc.items()}
         log_metrics(logger, train_metrics, epoch, prefix="Train")
-        
+
         return train_metrics
     
     @torch.no_grad()
@@ -492,8 +504,7 @@ class Trainer:
 
                 report_path = self.output_dir / 'evaluation' / f'{name}_report.json'
                 if report_path.exists():
-                    import json
-                    with open(report_path) as f:
+                    with open(report_path, 'r', encoding='utf-8') as f:
                         report = json.load(f)
                         metrics = report.get('technical_metrics', {})
                         training_info['mAP50'] = metrics.get('mAP50', 0)
@@ -514,8 +525,17 @@ class Trainer:
     def _resume_from_checkpoint(self, checkpoint_path: str) -> None:
         """Resume training from checkpoint."""
         logger.info("Resuming from: %s", checkpoint_path)
-        for trainer in self.trainers.values():
-            trainer.load_checkpoint(checkpoint_path)
+        for name, trainer in self.trainers.items():
+            if checkpoint_path in ('best', 'last'):
+                # Each checkpoint manager resolves this relative to its own output_dir
+                trainer.load_checkpoint(checkpoint_path)
+            else:
+                # Treat as experiment root; each model saves under output_dir/{name}/
+                model_path = Path(checkpoint_path) / name / 'best.pth'
+                if model_path.exists():
+                    trainer.load_checkpoint(str(model_path))
+                else:
+                    logger.warning("No checkpoint for %s at %s, skipping resume", name, model_path)
 
 
 # Backward compatibility alias

--- a/ml_engine/training/training_manager.py
+++ b/ml_engine/training/training_manager.py
@@ -78,28 +78,47 @@ class TrainingManager:
         self.optimizer = optimizer
         self.scheduler = scheduler
 
-        # Mixed precision (use default scaler params)
-        self.use_amp = config.get('mixed_precision', {}).get('enabled', False)
-        self.scaler = GradScaler() if self.use_amp else None
+        # Mixed precision — wire all GradScaler params from config
+        amp_cfg = config.get('mixed_precision', {})
+        self.use_amp = amp_cfg.get('enabled', False)
         if self.use_amp:
-            logger.info("AMP enabled")
-        
+            self.scaler = GradScaler(
+                init_scale=amp_cfg.get('init_scale', 65536),
+                growth_factor=amp_cfg.get('growth_factor', 2.0),
+                backoff_factor=amp_cfg.get('backoff_factor', 0.5),
+                growth_interval=amp_cfg.get('growth_interval', 2000),
+            )
+            logger.info("AMP enabled (init_scale=%s)", amp_cfg.get('init_scale', 65536))
+        else:
+            self.scaler = None
+
         # Gradient clipping
         clip_cfg = config.get('gradient_clipping', {})
         self.clip_enabled = clip_cfg.get('enabled', False)
         self.clip_max_norm = clip_cfg.get('max_norm', 1.0)
         self.clip_norm_type = clip_cfg.get('norm_type', 2.0)
+        self.clip_error_if_nonfinite = clip_cfg.get('error_if_nonfinite', False)
         if self.clip_enabled:
-            logger.info("Gradient clipping enabled (max_norm=%s)", self.clip_max_norm)
-        
+            logger.info(
+                "Gradient clipping enabled (max_norm=%s, error_if_nonfinite=%s)",
+                self.clip_max_norm, self.clip_error_if_nonfinite
+            )
+
+        # Gradient accumulation
+        accum_cfg = config.get('gradient_accumulation', {})
+        self.accumulation_steps = max(1, accum_cfg.get('steps', 1))
+        if self.accumulation_steps > 1:
+            logger.info("Gradient accumulation: %d steps (effective batch ×%d)",
+                        self.accumulation_steps, self.accumulation_steps)
+
         # Freeze BatchNorm for LoRA training
         norm_cfg = config.get('normalization', {})
         if norm_cfg.get('freeze_bn_teacher', False):
             self._freeze_batch_norm()
-        
+
         # Step counter for gradient accumulation
         self.global_step = 0
-    
+
     def _freeze_batch_norm(self) -> None:
         """Freeze BatchNorm layers for LoRA training."""
         logger.info("Freezing BatchNorm layers for LoRA training")
@@ -110,12 +129,12 @@ class TrainingManager:
                 for param in module.parameters():
                     param.requires_grad = False
         logger.info("BatchNorm frozen")
-    
+
     def training_step(
         self,
         batch: Dict,
         compute_loss_fn: Callable,
-        accumulation_steps: int = 1
+        accumulation_steps: Optional[int] = None,
     ) -> Dict[str, torch.Tensor]:
         """
         Execute one training step with AMP and gradient clipping.
@@ -128,19 +147,22 @@ class TrainingManager:
         Returns:
             Dict with loss and metrics
         """
+        if accumulation_steps is None:
+            accumulation_steps = self.accumulation_steps
+
         # Zero gradients at start of accumulation cycle
         if self.global_step % accumulation_steps == 0:
             self.optimizer.zero_grad(set_to_none=True)
-        
+
         if self.use_amp:
             with autocast(device_type='cuda'):
                 loss_dict = compute_loss_fn(batch)
                 loss = loss_dict['loss']
-            
+
             # Scale loss for accumulation
             scaled_loss = loss / accumulation_steps
             self.scaler.scale(scaled_loss).backward()
-            
+
             # Update weights after accumulation
             if (self.global_step + 1) % accumulation_steps == 0:
                 if self.clip_enabled:
@@ -148,35 +170,37 @@ class TrainingManager:
                     torch.nn.utils.clip_grad_norm_(
                         self.model.parameters(),
                         max_norm=self.clip_max_norm,
-                        norm_type=self.clip_norm_type
+                        norm_type=self.clip_norm_type,
+                        error_if_nonfinite=self.clip_error_if_nonfinite,
                     )
-                
+
                 self.scaler.step(self.optimizer)
                 self.scaler.update()
-                
+
                 if self.scheduler is not None:
                     self.scheduler.step()
         else:
             loss_dict = compute_loss_fn(batch)
             loss = loss_dict['loss']
-            
+
             scaled_loss = loss / accumulation_steps
             scaled_loss.backward()
-            
+
             if (self.global_step + 1) % accumulation_steps == 0:
                 if self.clip_enabled:
                     torch.nn.utils.clip_grad_norm_(
                         self.model.parameters(),
                         max_norm=self.clip_max_norm,
-                        norm_type=self.clip_norm_type
+                        norm_type=self.clip_norm_type,
+                        error_if_nonfinite=self.clip_error_if_nonfinite,
                     )
-                
+
                 self.optimizer.step()
-                
+
                 if self.scheduler is not None:
                     self.scheduler.step()
-        
+
         self.global_step += 1
         loss_dict['lr'] = self.optimizer.param_groups[0]['lr']
-        
+
         return loss_dict

--- a/ml_engine/training/training_manager.py
+++ b/ml_engine/training/training_manager.py
@@ -50,7 +50,6 @@ class TrainingManager:
         model: nn.Module,
         optimizer: torch.optim.Optimizer,
         config_path: str,
-        scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
         config_overrides: Optional[Dict] = None,
     ):
         """
@@ -58,11 +57,14 @@ class TrainingManager:
             model: The model being trained
             optimizer: The optimizer
             config_path: Path to training dynamics config YAML
-            scheduler: Optional learning rate scheduler
             config_overrides: Dict of training_dynamics overrides from experiment loop.
                 Deep-merged over the YAML values after loading. Keys match the YAML
                 structure under the top-level 'training_dynamics' key, e.g.
                 {'gradient_clipping': {'max_norm': 0.5}, 'mixed_precision': {'enabled': False}}.
+
+        Note: LR scheduler stepping is intentionally NOT handled here. TrainingManager
+        is a per-batch primitive (AMP, clipping, accumulation). Epoch-level concerns
+        like scheduler stepping belong in BaseModelTrainer / Trainer.
         """
         with open(config_path, 'r', encoding='utf-8') as f:
             config = yaml.safe_load(f)
@@ -76,7 +78,6 @@ class TrainingManager:
 
         self.model = model
         self.optimizer = optimizer
-        self.scheduler = scheduler
 
         # Mixed precision — wire all GradScaler params from config
         amp_cfg = config.get('mixed_precision', {})
@@ -111,30 +112,37 @@ class TrainingManager:
             logger.info("Gradient accumulation: %d steps (effective batch ×%d)",
                         self.accumulation_steps, self.accumulation_steps)
 
-        # Freeze BatchNorm for LoRA training
+        # Freeze BatchNorm for LoRA training.
+        # _freeze_bn is stored so training_step() can re-apply eval() after
+        # each model.train() call (which would otherwise undo the freeze).
         norm_cfg = config.get('normalization', {})
-        if norm_cfg.get('freeze_bn_teacher', False):
+        self._freeze_bn = norm_cfg.get('freeze_bn_teacher', False)
+        if self._freeze_bn:
             self._freeze_batch_norm()
 
         # Step counter for gradient accumulation
         self.global_step = 0
 
     def _freeze_batch_norm(self) -> None:
-        """Freeze BatchNorm layers for LoRA training."""
-        logger.info("Freezing BatchNorm layers for LoRA training")
+        """
+        Freeze BatchNorm layers for LoRA training.
+
+        Sets BN to eval mode so it uses the pre-trained running statistics
+        (running_mean / running_var) rather than batch statistics. This keeps
+        normalization stable with the small effective batch sizes typical of
+        LoRA runs. track_running_stats is intentionally left True — setting it
+        to False would make BN compute batch stats even in eval mode.
+        """
         for module in self.model.modules():
             if isinstance(module, (nn.BatchNorm2d, nn.BatchNorm1d)):
                 module.eval()
-                module.track_running_stats = False
                 for param in module.parameters():
                     param.requires_grad = False
-        logger.info("BatchNorm frozen")
 
     def training_step(
         self,
         batch: Dict,
         compute_loss_fn: Callable,
-        accumulation_steps: Optional[int] = None,
     ) -> Dict[str, torch.Tensor]:
         """
         Execute one training step with AMP and gradient clipping.
@@ -142,29 +150,35 @@ class TrainingManager:
         Args:
             batch: Input batch
             compute_loss_fn: Function that computes loss given batch
-            accumulation_steps: Number of steps to accumulate gradients
         
         Returns:
             Dict with loss and metrics
         """
-        if accumulation_steps is None:
-            accumulation_steps = self.accumulation_steps
+        # Set training mode here (not in BaseModelTrainer) so that the BN
+        # re-freeze happens atomically: model.train() sets all submodules to
+        # train mode, then _freeze_batch_norm() immediately overrides BN back
+        # to eval. Without this, model.train() in base.py would undo the freeze
+        # set during __init__.
+        self.model.train()
+        if self._freeze_bn:
+            self._freeze_batch_norm()
 
         # Zero gradients at start of accumulation cycle
-        if self.global_step % accumulation_steps == 0:
+        if self.global_step % self.accumulation_steps == 0:
             self.optimizer.zero_grad(set_to_none=True)
 
         if self.use_amp:
-            with autocast(device_type='cuda'):
+            device_type = next(self.model.parameters()).device.type
+            with autocast(device_type=device_type):
                 loss_dict = compute_loss_fn(batch)
                 loss = loss_dict['loss']
 
             # Scale loss for accumulation
-            scaled_loss = loss / accumulation_steps
+            scaled_loss = loss / self.accumulation_steps
             self.scaler.scale(scaled_loss).backward()
 
             # Update weights after accumulation
-            if (self.global_step + 1) % accumulation_steps == 0:
+            if (self.global_step + 1) % self.accumulation_steps == 0:
                 if self.clip_enabled:
                     self.scaler.unscale_(self.optimizer)
                     torch.nn.utils.clip_grad_norm_(
@@ -176,17 +190,14 @@ class TrainingManager:
 
                 self.scaler.step(self.optimizer)
                 self.scaler.update()
-
-                if self.scheduler is not None:
-                    self.scheduler.step()
         else:
             loss_dict = compute_loss_fn(batch)
             loss = loss_dict['loss']
 
-            scaled_loss = loss / accumulation_steps
+            scaled_loss = loss / self.accumulation_steps
             scaled_loss.backward()
 
-            if (self.global_step + 1) % accumulation_steps == 0:
+            if (self.global_step + 1) % self.accumulation_steps == 0:
                 if self.clip_enabled:
                     torch.nn.utils.clip_grad_norm_(
                         self.model.parameters(),
@@ -196,9 +207,6 @@ class TrainingManager:
                     )
 
                 self.optimizer.step()
-
-                if self.scheduler is not None:
-                    self.scheduler.step()
 
         self.global_step += 1
         loss_dict['lr'] = self.optimizer.param_groups[0]['lr']

--- a/tests/unit/test_lora.py
+++ b/tests/unit/test_lora.py
@@ -3,21 +3,21 @@ Unit tests for LoRA (Parameter-Efficient Fine-Tuning) utilities.
 
 Tests:
 - LoRA application
-- Freezing verification
-- Parameter counting
-- Adapter saving/loading
+- Freezing verification (both strict and non-strict paths)
+- Adapter saving and error handling
+- Module freeze/unfreeze
 """
 
+import os
 import unittest
+import tempfile
 import torch
 import torch.nn as nn
-import tempfile
-from pathlib import Path
 
 
 class SimpleModel(nn.Module):
     """Simple model for testing LoRA."""
-    
+
     def __init__(self):
         super().__init__()
         self.conv1 = nn.Conv2d(3, 64, 3)
@@ -29,7 +29,7 @@ class SimpleModel(nn.Module):
             'out_proj': nn.Linear(64, 64)
         })
         self.fc = nn.Linear(64, 10)
-    
+
     def forward(self, x):
         x = self.conv1(x)
         x = self.bn1(x)
@@ -39,7 +39,7 @@ class SimpleModel(nn.Module):
 
 class TestLoRAUtilities(unittest.TestCase):
     """Test LoRA utilities."""
-    
+
     def setUp(self):
         """Create a simple model for testing."""
         self.model = SimpleModel()
@@ -49,114 +49,116 @@ class TestLoRAUtilities(unittest.TestCase):
             'lora_dropout': 0.1,
             'target_modules': ['q_proj', 'k_proj', 'v_proj']
         }
-    
+
     def test_apply_lora(self):
         """Test applying LoRA to model."""
         from ml_engine.training.peft_utils import apply_lora
-        
+
         original_params = sum(p.numel() for p in self.model.parameters())
-        
+
         # Apply LoRA
         model_with_lora = apply_lora(self.model, self.lora_config)
-        
+
         # Check that model has more parameters now (LoRA adapters added)
         lora_params = sum(p.numel() for p in model_with_lora.parameters())
         self.assertGreater(lora_params, original_params)
-    
+
     def test_verify_freezing(self):
-        """Test freezing verification."""
+        """Test freezing verification in non-strict mode."""
         from ml_engine.training.peft_utils import apply_lora, verify_freezing
-        
+
         # Apply LoRA
         model_with_lora = apply_lora(self.model, self.lora_config)
-        
+
         # Verify freezing
         stats = verify_freezing(model_with_lora, strict=False)
-        
+
         # Check that most parameters are frozen
         self.assertGreater(stats['frozen_params'], 0)
         self.assertGreater(stats['trainable_params'], 0)
         self.assertLess(stats['trainable_ratio'], 50.0)  # Should be much less than 50%
-    
-    def test_trainable_parameters_are_lora(self):
-        """Test that only LoRA parameters are trainable."""
-        from ml_engine.training.peft_utils import apply_lora
-        
+
+    def test_verify_freezing_strict_raises_on_non_lora_trainable(self):
+        """Test that strict mode raises when non-LoRA params are trainable."""
+        from ml_engine.training.peft_utils import apply_lora, verify_freezing
+
         model_with_lora = apply_lora(self.model, self.lora_config)
-        
+
+        # Manually make a non-LoRA parameter trainable to trigger strict error
+        for name, param in model_with_lora.named_parameters():
+            if 'lora' not in name.lower():
+                param.requires_grad = True
+                break
+
+        with self.assertRaises(AssertionError) as ctx:
+            verify_freezing(model_with_lora, strict=True)
+
+        self.assertIn("Non-LoRA param is trainable", str(ctx.exception))
+
+    def test_trainable_parameters_are_lora(self):
+        """Test that only LoRA parameters are trainable after apply_lora."""
+        from ml_engine.training.peft_utils import apply_lora
+
+        model_with_lora = apply_lora(self.model, self.lora_config)
+
         # Check each trainable parameter
         for name, param in model_with_lora.named_parameters():
             if param.requires_grad:
                 # All trainable params should have 'lora' in name
                 self.assertIn('lora', name.lower(),
-                            f"Trainable parameter without 'lora' in name: {name}")
-    
+                              f"Trainable parameter without 'lora' in name: {name}")
+
     def test_freeze_module(self):
         """Test module freezing."""
         from ml_engine.training.peft_utils import freeze_module
-        
+
         # Freeze conv layer
         freeze_module(self.model.conv1)
-        
+
         # Check all params are frozen
         for param in self.model.conv1.parameters():
             self.assertFalse(param.requires_grad)
-    
-    def test_count_lora_parameters(self):
-        """Test LoRA parameter counting."""
-        from ml_engine.training.peft_utils import apply_lora, count_lora_parameters
-        
-        model_with_lora = apply_lora(self.model, self.lora_config)
-        lora_counts = count_lora_parameters(model_with_lora)
-        
-        # Should have LoRA parameters
-        self.assertGreater(lora_counts['total_lora_params'], 0)
-    
-    def test_get_lora_rank(self):
-        """Test getting LoRA rank."""
-        from ml_engine.training.peft_utils import apply_lora, get_lora_rank
-        
-        model_with_lora = apply_lora(self.model, self.lora_config)
-        rank = get_lora_rank(model_with_lora)
-        
-        if rank is not None:
-            self.assertEqual(rank, self.lora_config['r'])
 
+    def test_unfreeze_module(self):
+        """Test module unfreezing."""
+        from ml_engine.training.peft_utils import freeze_module, unfreeze_module
 
-class TestPartialFreeze(unittest.TestCase):
-    """Test partial freezing strategies."""
-    
-    def setUp(self):
-        """Create model."""
-        self.model = SimpleModel()
-    
-    def test_partial_freeze_for_lora(self):
-        """Test partial freeze + LoRA strategy."""
-        from ml_engine.training.peft_utils import partial_freeze_for_lora
-        
-        lora_config = {
-            'r': 4,
-            'lora_alpha': 8,
-            'target_modules': ['q_proj', 'v_proj']
-        }
-        
-        model = partial_freeze_for_lora(
-            self.model,
-            freeze_modules=['conv1', 'bn1'],
-            lora_config=lora_config,
-            lora_modules=['self_attn']
-        )
-        
-        # Check that specified modules are frozen
+        # First freeze
+        freeze_module(self.model.conv1)
         for param in self.model.conv1.parameters():
             self.assertFalse(param.requires_grad)
-        
-        # Should have trainable LoRA params
-        trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
-        self.assertGreater(trainable, 0)
+
+        # Then unfreeze
+        unfreeze_module(self.model.conv1)
+        for param in self.model.conv1.parameters():
+            self.assertTrue(param.requires_grad)
+
+    def test_save_lora_adapters_happy_path(self):
+        """Test that LoRA adapters are written to disk."""
+        from ml_engine.training.peft_utils import apply_lora, save_lora_adapters
+
+        model_with_lora = apply_lora(self.model, self.lora_config)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_lora_adapters(model_with_lora, tmpdir)
+            saved_files = os.listdir(tmpdir)
+            self.assertTrue(
+                len(saved_files) > 0,
+                "save_lora_adapters wrote no files to output_dir"
+            )
+            # PEFT always writes adapter_config.json
+            self.assertIn('adapter_config.json', saved_files)
+
+    def test_save_lora_adapters_non_peft_model_raises(self):
+        """Test that saving a non-PEFT model raises ValueError."""
+        from ml_engine.training.peft_utils import save_lora_adapters
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(ValueError) as ctx:
+                save_lora_adapters(self.model, tmpdir)
+
+            self.assertIn("save_pretrained", str(ctx.exception))
 
 
 if __name__ == '__main__':
     unittest.main()
-
-

--- a/tests/unit/test_losses.py
+++ b/tests/unit/test_losses.py
@@ -1,0 +1,305 @@
+"""
+Unit tests for loss functions.
+
+Tests:
+- HungarianMatcher: bipartite matching with token-level classification cost
+- GroundingDINOCriterion: full DETR-style loss (labels + boxes + aux)
+- build_criterion: sanity check on weight dict construction
+- SegmentationLoss: forward pass including all-invalid-masks edge case
+"""
+
+import unittest
+import torch
+import torch.nn as nn
+
+
+def _make_matcher_outputs(B: int, N: int, num_tokens: int, device="cpu"):
+    """Synthetic HungarianMatcher inputs."""
+    outputs = {
+        "pred_logits": torch.randn(B, N, num_tokens, device=device),
+        "pred_boxes": torch.rand(B, N, 4, device=device),
+    }
+    return outputs
+
+
+def _make_matcher_targets(B: int, M: int, num_tokens: int, device="cpu"):
+    """Synthetic targets with M objects per image."""
+    targets = []
+    for _ in range(B):
+        targets.append({
+            "labels": torch.zeros(M, dtype=torch.long, device=device),
+            "boxes": torch.rand(M, 4, device=device),
+            "token_labels": torch.randint(0, 2, (M, num_tokens), dtype=torch.float, device=device),
+        })
+    return targets
+
+
+class TestHungarianMatcher(unittest.TestCase):
+    """Tests for HungarianMatcher bipartite matching."""
+
+    def setUp(self):
+        from ml_engine.training.losses import HungarianMatcher
+        self.matcher = HungarianMatcher(cost_class=1.0, cost_bbox=5.0, cost_giou=2.0)
+
+    def test_output_shape(self):
+        """Each batch element gets one (pred_idx, tgt_idx) tuple."""
+        B, N, M, T = 2, 10, 3, 20
+        outputs = _make_matcher_outputs(B, N, T)
+        targets = _make_matcher_targets(B, M, T)
+
+        indices = self.matcher(outputs, targets)
+
+        self.assertEqual(len(indices), B)
+        for pred_idx, tgt_idx in indices:
+            # Each matched pair has the same length
+            self.assertEqual(len(pred_idx), len(tgt_idx))
+            # Indices within valid range
+            self.assertTrue((pred_idx < N).all())
+            self.assertTrue((tgt_idx < M).all())
+
+    def test_single_target(self):
+        """With 1 target per image, exactly 1 match per image."""
+        B, N, M, T = 2, 10, 1, 20
+        outputs = _make_matcher_outputs(B, N, T)
+        targets = _make_matcher_targets(B, M, T)
+
+        indices = self.matcher(outputs, targets)
+
+        for pred_idx, tgt_idx in indices:
+            self.assertEqual(len(pred_idx), 1)
+
+    def test_with_text_token_mask(self):
+        """Matcher handles text_token_mask correctly (no crash)."""
+        B, N, M, T = 2, 10, 3, 20
+        outputs = _make_matcher_outputs(B, N, T)
+        outputs["text_token_mask"] = torch.ones(B, T, dtype=torch.bool)
+        targets = _make_matcher_targets(B, M, T)
+
+        indices = self.matcher(outputs, targets)
+        self.assertEqual(len(indices), B)
+
+
+class TestGroundingDINOCriterion(unittest.TestCase):
+    """Tests for GroundingDINOCriterion full forward pass."""
+
+    def setUp(self):
+        from ml_engine.training.losses import build_criterion
+        self.criterion = build_criterion(num_classes=80, num_decoder_layers=2)
+
+    def test_forward_returns_expected_keys(self):
+        """Forward pass produces loss_ce, loss_bbox, loss_giou keys."""
+        B, N, T = 2, 10, 20
+        outputs = {
+            "pred_logits": torch.randn(B, N, T),
+            "pred_boxes": torch.rand(B, N, 4),
+        }
+        targets = _make_matcher_targets(B, M=3, num_tokens=T)
+
+        losses = self.criterion(outputs, targets)
+
+        self.assertIn("loss_ce", losses)
+        self.assertIn("loss_bbox", losses)
+        self.assertIn("loss_giou", losses)
+
+    def test_auxiliary_losses(self):
+        """Auxiliary decoder losses are keyed with _0, _1, ... suffixes."""
+        B, N, T = 2, 10, 20
+        aux_outputs = [
+            {"pred_logits": torch.randn(B, N, T), "pred_boxes": torch.rand(B, N, 4)}
+        ]
+        outputs = {
+            "pred_logits": torch.randn(B, N, T),
+            "pred_boxes": torch.rand(B, N, 4),
+            "aux_outputs": aux_outputs,
+        }
+        targets = _make_matcher_targets(B, M=2, num_tokens=T)
+
+        losses = self.criterion(outputs, targets)
+
+        self.assertIn("loss_ce_0", losses)
+        self.assertIn("loss_bbox_0", losses)
+
+    def test_losses_are_finite(self):
+        """No NaN or Inf in any loss component."""
+        B, N, T = 2, 10, 20
+        outputs = {
+            "pred_logits": torch.randn(B, N, T),
+            "pred_boxes": torch.rand(B, N, 4),
+        }
+        targets = _make_matcher_targets(B, M=3, num_tokens=T)
+
+        losses = self.criterion(outputs, targets)
+
+        for name, val in losses.items():
+            self.assertFalse(torch.isnan(val).any(), f"NaN in {name}")
+            self.assertFalse(torch.isinf(val).any(), f"Inf in {name}")
+
+    def test_enc_outputs_produces_enc_keys(self):
+        """
+        enc_outputs path produces loss_*_enc keys.
+
+        The encoder uses binary objectness targets (token_labels=all-ones, labels=all-zeros)
+        so every valid token is equally activated — different signal from the decoder path.
+        This test verifies the path runs and keys are present.
+        """
+        B, N, T = 2, 10, 20
+        outputs = {
+            "pred_logits": torch.randn(B, N, T),
+            "pred_boxes": torch.rand(B, N, 4),
+            "enc_outputs": {
+                "pred_logits": torch.randn(B, N, T),
+                "pred_boxes": torch.rand(B, N, 4),
+            },
+        }
+        targets = _make_matcher_targets(B, M=2, num_tokens=T)
+
+        losses = self.criterion(outputs, targets)
+
+        self.assertIn("loss_ce_enc", losses)
+        self.assertIn("loss_bbox_enc", losses)
+        self.assertIn("loss_giou_enc", losses)
+        for name in ("loss_ce_enc", "loss_bbox_enc", "loss_giou_enc"):
+            self.assertFalse(torch.isnan(losses[name]).any(), f"NaN in {name}")
+
+    def test_backward_gradient_flow(self):
+        """
+        Regression: weighted total loss must support .backward() with no NaN gradients.
+
+        A NaN in any auxiliary loss component would silently zero out or corrupt gradients
+        if not caught here. This test mirrors what GroundingDINOTrainer.compute_loss() does.
+        """
+        B, N, T = 2, 10, 20
+        pred_logits = torch.randn(B, N, T, requires_grad=True)
+        pred_boxes = torch.rand(B, N, 4, requires_grad=True)
+        aux_pred_logits = torch.randn(B, N, T, requires_grad=True)
+        aux_pred_boxes = torch.rand(B, N, 4, requires_grad=True)
+
+        outputs = {
+            "pred_logits": pred_logits,
+            "pred_boxes": pred_boxes,
+            "aux_outputs": [
+                {"pred_logits": aux_pred_logits, "pred_boxes": aux_pred_boxes}
+            ],
+        }
+        targets = _make_matcher_targets(B, M=3, num_tokens=T)
+
+        loss_dict = self.criterion(outputs, targets)
+
+        total_loss = sum(
+            loss_dict[k] * self.criterion.weight_dict[k]
+            for k in loss_dict
+            if k in self.criterion.weight_dict
+        )
+
+        # Must not raise
+        total_loss.backward()
+
+        # Gradients must exist and be finite
+        for name, param in [("pred_logits", pred_logits), ("pred_boxes", pred_boxes)]:
+            self.assertIsNotNone(param.grad, f"No gradient on {name}")
+            self.assertFalse(torch.isnan(param.grad).any(), f"NaN gradient on {name}")
+
+
+class TestBuildCriterion(unittest.TestCase):
+    """Tests for build_criterion weight dict construction."""
+
+    def test_weight_dict_covers_all_decoder_layers(self):
+        """weight_dict has entries for all aux layers and encoder."""
+        from ml_engine.training.losses import build_criterion
+        num_layers = 4
+        criterion = build_criterion(num_classes=10, num_decoder_layers=num_layers)
+
+        # Aux losses: 0 .. num_layers-2
+        for i in range(num_layers - 1):
+            self.assertIn(f"loss_ce_{i}", criterion.weight_dict)
+            self.assertIn(f"loss_bbox_{i}", criterion.weight_dict)
+            self.assertIn(f"loss_giou_{i}", criterion.weight_dict)
+
+        # Encoder
+        self.assertIn("loss_ce_enc", criterion.weight_dict)
+        self.assertIn("loss_bbox_enc", criterion.weight_dict)
+        self.assertIn("loss_giou_enc", criterion.weight_dict)
+
+    def test_weight_values(self):
+        """Paper weights: loss_ce=2.0, loss_bbox=5.0, loss_giou=2.0."""
+        from ml_engine.training.losses import build_criterion
+        criterion = build_criterion(num_classes=10)
+
+        self.assertAlmostEqual(criterion.weight_dict["loss_ce"], 2.0)
+        self.assertAlmostEqual(criterion.weight_dict["loss_bbox"], 5.0)
+        self.assertAlmostEqual(criterion.weight_dict["loss_giou"], 2.0)
+
+
+class TestSegmentationLoss(unittest.TestCase):
+    """Tests for SegmentationLoss, focusing on edge cases."""
+
+    def setUp(self):
+        from ml_engine.training.losses import SegmentationLoss
+        self.loss_fn = SegmentationLoss()
+
+    def test_all_invalid_masks_backward(self):
+        """
+        Regression: all-invalid valid_mask must not crash .backward().
+
+        Zero tensors without requires_grad=True cause:
+            RuntimeError: element 0 of tensors does not require grad
+        """
+        B, N, H, W = 2, 3, 16, 16
+        pred_masks = torch.randn(B, N, H, W, requires_grad=True)
+        predictions = {"pred_masks": pred_masks}
+        targets = {
+            "masks": torch.zeros(B, N, H, W),
+            "valid_mask": torch.zeros(B, N, dtype=torch.bool),  # all invalid
+        }
+
+        loss_dict = self.loss_fn(predictions, targets)
+
+        # Must not raise — this was the bug
+        loss_dict["loss"].backward()
+
+    def test_all_invalid_masks_returns_zero(self):
+        """All-invalid path returns zero loss."""
+        B, N, H, W = 2, 3, 16, 16
+        predictions = {"pred_masks": torch.randn(B, N, H, W)}
+        targets = {
+            "masks": torch.zeros(B, N, H, W),
+            "valid_mask": torch.zeros(B, N, dtype=torch.bool),
+        }
+
+        loss_dict = self.loss_fn(predictions, targets)
+
+        self.assertEqual(loss_dict["loss"].item(), 0.0)
+
+    def test_happy_path_produces_valid_loss(self):
+        """Standard forward pass with all-valid masks."""
+        B, N, H, W = 2, 3, 16, 16
+        predictions = {"pred_masks": torch.randn(B, N, H, W)}
+        targets = {
+            "masks": torch.randint(0, 2, (B, N, H, W)).float(),
+            "valid_mask": torch.ones(B, N, dtype=torch.bool),
+        }
+
+        loss_dict = self.loss_fn(predictions, targets)
+
+        self.assertFalse(torch.isnan(loss_dict["loss"]))
+        self.assertGreater(loss_dict["loss"].item(), 0.0)
+
+    def test_partial_valid_mask(self):
+        """Partial valid_mask uses only valid entries."""
+        B, N, H, W = 2, 4, 16, 16
+        valid_mask = torch.zeros(B, N, dtype=torch.bool)
+        valid_mask[:, :2] = True  # first 2 objects valid
+
+        predictions = {"pred_masks": torch.randn(B, N, H, W)}
+        targets = {
+            "masks": torch.randint(0, 2, (B, N, H, W)).float(),
+            "valid_mask": valid_mask,
+        }
+
+        loss_dict = self.loss_fn(predictions, targets)
+
+        self.assertFalse(torch.isnan(loss_dict["loss"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Gradient accumulation**: accumulate N micro-batches before each optimizer update — zero extra VRAM (`--grad-accum N` CLI flag, `training_dynamics.gradient_accumulation.steps` config)
- **AMP**: full GradScaler config from YAML (`init_scale`, `growth_factor`, `backoff_factor`, `growth_interval`); dynamic `device_type` for autocast
- **LR scheduler fix**: steps once per epoch, not per optimizer update — was compressing CosineAnnealingWarmRestarts by `accum_steps × batches_per_epoch`
- **BN freeze fix**: removed `track_running_stats = False` that made BN use batch stats even in eval mode

## Loss correctness

- Per-mask dice/IoU: sum over spatial dim then mean — was global flatten, biased toward large masks
- `class_error`: positive-token recall (was token accuracy, ~99.9% for any model)
- Unmatched GT boxes → 0 IoU/Dice; without this, 10% recall can report mIoU=1.0
- `HungarianMatcher`: always focal; dead `use_focal`/`tgt_ids`/`tokenizer` args removed; `cost_class` via matmul
- Encoder `bin_targets`: all-ones `token_labels` for objectness (not class-specific)
- `requires_grad=True` on zero-tensor fallbacks for empty batches

## Model / trainer

- GroundingDINO: cache `text_token_mask` and `positive_map` by caption key (tokenize once)
- GroundingDINO: `hasattr`-based PEFT unwrap; NaN batch skip with zero-grad loss
- SAM: differential LR (mask decoder at `mask_decoder_lr_multiplier × lr`, LoRA at base)
- SAM trainer + evaluator: trim forward pass to `max_valid` boxes
- Early stopping: fixed double-break bug (only exited inner trainer loop, not epoch loop)

## Dead code removed

`CombinedTeacherLoss`, `load_lora_model`, `partial_freeze_for_lora`, `get_trainable_parameters_summary`, `count_lora_parameters`, `get_lora_rank`, `enable/disable_lora_dropout`, `_get_tgt_permutation_idx`, `multimask_output` YAML key, peft_utils warning string tuple bug
