### PR TITLE
test(augmentation): error-path coverage for _validate_bboxes (44 tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,7 +839,11 @@ before each `git commit`. Green here ≈ green in CI.
 One-time setup per machine:
 
 ```bash
-uv sync --extra dev          # installs pre-commit into .venv
+# `dev` brings in pre-commit itself; `lint` brings in ruff + mypy so the
+# hooks can resolve them from .venv. `cpu` (or `gpu` if you have a GPU)
+# picks the torch variant — pre-commit hooks run `uv run --no-sync` so
+# the binaries must already be installed, not re-resolved per invocation.
+uv sync --extra dev --extra lint --extra cpu
 uv run pre-commit install    # wires up .git/hooks/pre-commit
 ```
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -76,23 +76,9 @@ Three related design gaps surfaced during the first `/plan → /approve` integra
 
 Six items deferred during the `/plan-eng-review` of the CI/test infrastructure PR. Filed 2026-04-23. All depend on the `ci-and-tests` branch merging first.
 
-### 4. Pre-commit hooks (ruff + mypy + pytest on staged files)
-
-**What:** Add `.pre-commit-config.yaml` wiring `ruff`, `ruff-format`, `mypy`, and `pytest` on staged files. Document `pre-commit install` in README onboarding.
-
-**Why:** Shift-left from CI to the developer's machine. Sub-second feedback on lint violations. Catches issues before PR is opened, saving CI minutes.
-
-**Pros:** Instant feedback loop. Zero CI cost. Reduces "forgot to run pytest" class of regressions even further.
-
-**Cons:** Adds `.pre-commit-config.yaml` maintenance. Onboarding requires `pre-commit install` step. Can slow down rebase-heavy workflows if hooks are slow.
-
-**Context:** Natural shift-left follow-up now that CI runs the same checks on every push. `ruff check .` and `uv run mypy core ml_engine api` are already the CI commands — pre-commit just runs them locally first.
-
-**Depends on / blocked by:** `ci-and-tests` PR merging (so pre-commit and CI run the same linters).
-
----
-
 ### 5. Dependabot config for Python + GitHub Actions updates
+
+**Status:** 🟡 PR open on `chore/dependabot` (2026-04-24). Scope expanded in-flight to include the Dockerfile `TORCH_CUDA_ARCH_LIST` broad-arch expansion — one coordinated PR covers both "stay current on deps" and "run on all NVIDIA generations."
 
 **What:** Add `.github/dependabot.yml` with weekly schedule for `pip` (uv ecosystem via pyproject.toml) and `github-actions` ecosystems.
 
@@ -172,22 +158,6 @@ Six items deferred during the `/plan-eng-review` of the CI/test infrastructure P
 
 ---
 
-### 10. Error-path coverage for `augmentation_factory._validate_bboxes`
-
-**What:** Add a dedicated `tests/unit/augmentation/test_augmentation_factory.py` that parametrizes every error branch of the COCO-format validator: `None` is valid, `[]` is valid, `[[]]` raises, non-list raises, bbox with len != 4 raises, negative `w`/`h` raise, out-of-image `x`/`y` raise, `x + w > image_w` raises, `y + h > image_h` raises, string-integer coords accepted, string-float coords rejected, float coords rejected, non-int types rejected. Assert both the exception type (TypeError vs ValueError) and an error-message fragment.
-
-**Why:** The `/plan-eng-review` adversarial pass flagged that ~40 lines of new validation in `augmentation/augmentation_factory.py::_validate_bboxes` (the COCO-format rewrite) have zero error-path coverage. `tests/unit/test_augmentation.py::test_pipeline_application` only exercises the happy path with valid COCO bboxes. Any regression in the new validator branches goes undetected until a real COCO dataset hits it in a training run.
-
-**Pros:** Closes the error-path gap for a validator that the CI/test PR explicitly re-implemented. Each branch becomes regression-protected.
-
-**Cons:** None — this is Priority-2 unit test work per the design doc's New Unit Tests roster (item #9: "augmentation/test_augmentation_factory.py — factory dispatch + parameter validation").
-
-**Context:** The Priority-2 unit test roster in the ci-and-tests PR explicitly named this file. Deferred to this TODO because the PR is already at ~3400 lines new.
-
-**Depends on / blocked by:** `ci-and-tests` merging. No other blockers.
-
----
-
 ### 11. Inference module integration tests (detectors, segmenters, auto_labeler, visualizer)
 
 **What:** Add integration tests under `tests/integration/` against tiny real SAM/GroundingDINO weights for `ml_engine/inference/detectors/*`, `ml_engine/inference/segmenters/*`, `ml_engine/inference/auto_labeler.py`, `ml_engine/inference/visualizer.py`. Use a minimal checkpoint (e.g., `SAM-small` variant or custom-trained tiny weights) hosted as a CI fixture.
@@ -215,7 +185,7 @@ Six items deferred during the `/plan-eng-review` of the CI/test infrastructure P
 - `tests/unit/augmentation/test_characteristic_translator.py` — covers `augmentation/characteristic_translator.py` (~1362 lines — biggest target; triage to highest-value code paths first, don't boil this sub-ocean in one PR). Translation correctness between characteristic spec and concrete transform params.
 - `tests/unit/api/test_schemas.py` — covers `api/schemas.py` (~382 lines). API pydantic schemas: request/response envelope structure, required-field enforcement, validation-error shape.
 
-**Why:** The design doc (`~/.gstack/projects/hongthepotato-Grounded-Segment-Anything/shen_h-agentic-design-20260422-223526.md` lines 204-212) explicitly listed these as "include if time permits, follow-up PR otherwise." They were deferred, and without a tracking entry the promise was about to fall off the radar. Captured here so the bookkeeping survives the merge. TODO #10 already captures the seventh P2 file (`test_augmentation_factory.py`) with extra error-path detail — don't duplicate; do the two together if scheduling side-by-side makes sense.
+**Why:** The design doc (`~/.gstack/projects/hongthepotato-Grounded-Segment-Anything/shen_h-agentic-design-20260422-223526.md` lines 204-212) explicitly listed these as "include if time permits, follow-up PR otherwise." They were deferred, and without a tracking entry the promise was about to fall off the radar. Captured here so the bookkeeping survives the merge. The seventh P2 file (`test_augmentation_factory.py`) was covered by item 10 which has now shipped (see Completed section below).
 
 **Pros:**
 - Raises unit coverage above the 52% baseline the ratchet starts at, giving real headroom toward the 70% design target.
@@ -228,4 +198,45 @@ Six items deferred during the `/plan-eng-review` of the CI/test infrastructure P
 
 **Context:** Deferred from the original ci-and-tests PR (~3400 lines new) to keep that PR shippable. PR is CI-green at 52% combined coverage, merged with COVERAGE_MIN ratchet seeded at 50. Each new test file from this roster bumps real coverage and unlocks a COVERAGE_MIN bump in the same PR.
 
-**Depends on / blocked by:** `ci-and-tests` PR merging (for the test infrastructure and markers). No other blockers. Recommended sequencing: pair with TODO #10 (augmentation_factory error-path tests) if attacking the augmentation/ directory, since both touch related code.
+**Depends on / blocked by:** `ci-and-tests` PR merging (for the test infrastructure and markers). No other blockers. Recommended sequencing: look at `tests/unit/augmentation/test_augmentation_factory.py` (shipped in item 10) for the pytest-parametrize + class-grouping pattern when adding the augmentation/ tests in this item.
+
+---
+
+## Completed
+
+Historical record of items that have shipped. Kept rather than deleted so external
+references (commit messages, PR descriptions mentioning "item N") resolve.
+
+### 4. Pre-commit hooks ✅
+
+**Completed:** 2026-04-24 via PR #26 merged into `agentic`.
+
+**What shipped:** `.pre-commit-config.yaml` with file-hygiene hooks (trailing
+whitespace, EOF newline, YAML/TOML validity, large-file cap, merge conflict
+markers, private-key detection, debug-statements, Python AST validity) plus
+`ruff check`, `ruff format --check`, and `mypy` via `uv run --no-sync` so the
+hook binaries match CI exactly. Added `pre-commit>=3.6.0` to the `dev` extra.
+Onboarding: `uv sync --extra dev && uv run pre-commit install`.
+
+**Design notes worth remembering:** `--fix` deliberately NOT enabled for ruff
+because the ~3500-finding baseline would produce a destructive first-run diff.
+Per-file cleanup happens naturally as pre-commit flags new violations when
+you touch a file — see item 9.
+
+### 10. Error-path coverage for `augmentation_factory._validate_bboxes` ✅
+
+**Completed:** 2026-04-24 in the same PR as this Completed-section addition.
+
+**What shipped:** `tests/unit/augmentation/test_augmentation_factory.py` — 44
+parametrized tests across 7 test classes, one per error class:
+`TestValidInputs` (5), `TestInvalidContainer` (5), `TestInvalidBboxElement`
+(8), `TestInvalidCoordinateTypes` (8), `TestInvalidDimensions` (6),
+`TestOutOfBounds` (8), `TestErrorIndexing` (1). Every branch of the COCO
+validator exits under test: type mismatches raise `TypeError`, value/bounds
+mismatches raise `ValueError`, and the reported bbox index is 1-indexed.
+
+**Design notes worth remembering:** validator is called with `self=None`
+because its body uses no instance state — `self` is only there because it's
+an instance method. Avoids constructing a full augmentation pipeline for
+every test. Fast (~8s cold for all 44 tests), isolated from albumentations
+state.

--- a/tests/unit/augmentation/test_augmentation_factory.py
+++ b/tests/unit/augmentation/test_augmentation_factory.py
@@ -1,0 +1,246 @@
+"""
+Error-path coverage for ConfigurableAugmentationPipeline._validate_bboxes.
+
+Context: the validator was rewritten in the ci-and-tests PR (commit 5f501b8)
+to use COCO format [x, y, w, h] after a pascal-voc misinterpretation bug
+was discovered. Happy-path validation is exercised by
+tests/unit/test_augmentation.py::test_pipeline_application. This file covers
+every error branch of the validator itself.
+
+Error contract (from augmentation/augmentation_factory.py::_validate_bboxes):
+- TypeError for structural / type errors: wrong container type, wrong
+  element types, non-integer coordinates (incl. string-floats).
+- ValueError for value errors: wrong tuple length, non-positive dimensions,
+  out-of-bounds coordinates, bbox extending beyond the image.
+
+Validator is called statically with self=None. The method body uses no
+instance attributes; `self` is only there because it's an instance method.
+Skipping a full pipeline construction keeps these tests fast and isolated.
+"""
+
+import numpy as np
+import pytest
+
+from augmentation.augmentation_factory import ConfigurableAugmentationPipeline
+
+# Image dims for bounds tests. Chosen to be realistic, not round, so bugs
+# that accidentally hardcode dimensions surface clearly.
+IMG_H = 480
+IMG_W = 640
+
+# Alias: _validate_bboxes as a static callable.
+_validate = ConfigurableAugmentationPipeline._validate_bboxes
+
+
+# ---------------------------------------------------------------------------
+# Happy-path variants — these must NOT raise
+# ---------------------------------------------------------------------------
+
+
+class TestValidInputs:
+    def test_none_is_valid(self):
+        """`None` is the sentinel for 'no bboxes', per docstring."""
+        _validate(None, None, IMG_H, IMG_W)
+
+    def test_empty_list_is_valid(self):
+        """Empty list is the other 'no bboxes' representation."""
+        _validate(None, [], IMG_H, IMG_W)
+
+    def test_single_bbox_is_valid(self):
+        _validate(None, [[100, 100, 50, 50]], IMG_H, IMG_W)
+
+    def test_multiple_bboxes_are_valid(self):
+        _validate(None, [[0, 0, 10, 10], [100, 100, 50, 50]], IMG_H, IMG_W)
+
+    def test_bbox_spanning_full_image(self):
+        """x+w == image_w and y+h == image_h are both allowed (inclusive)."""
+        _validate(None, [[0, 0, IMG_W, IMG_H]], IMG_H, IMG_W)
+
+    @pytest.mark.parametrize(
+        "coord_example",
+        [
+            pytest.param(["100", "100", "50", "50"], id="string-integers"),
+            pytest.param(
+                [np.int32(100), np.int32(100), np.int32(50), np.int32(50)],
+                id="numpy-int32",
+            ),
+            pytest.param(
+                [np.int64(100), np.int64(100), np.int64(50), np.int64(50)],
+                id="numpy-int64",
+            ),
+        ],
+    )
+    def test_accepted_coord_types(self, coord_example):
+        """String-integers and numpy integer types are explicitly coerced to int."""
+        _validate(None, [coord_example], IMG_H, IMG_W)
+
+
+# ---------------------------------------------------------------------------
+# Container-level type errors (bboxes itself)
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidContainer:
+    @pytest.mark.parametrize(
+        "non_list",
+        [
+            pytest.param("not a list", id="string"),
+            pytest.param(42, id="int"),
+            pytest.param({"a": 1}, id="dict"),
+            pytest.param((1, 2, 3), id="tuple"),
+            pytest.param(np.array([[1, 2, 3, 4]]), id="ndarray"),
+        ],
+    )
+    def test_non_list_raises_typeerror(self, non_list):
+        with pytest.raises(TypeError, match="bboxes must be a list"):
+            _validate(None, non_list, IMG_H, IMG_W)
+
+
+# ---------------------------------------------------------------------------
+# Per-bbox structure errors
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidBboxElement:
+    @pytest.mark.parametrize(
+        "non_list_bbox",
+        [
+            pytest.param((1, 2, 3, 4), id="tuple"),
+            pytest.param("1,2,3,4", id="string"),
+            pytest.param(None, id="None"),
+            pytest.param(np.array([1, 2, 3, 4]), id="ndarray"),
+        ],
+    )
+    def test_non_list_bbox_element_raises_typeerror(self, non_list_bbox):
+        with pytest.raises(TypeError, match="bbox 1 must be a list"):
+            _validate(None, [non_list_bbox], IMG_H, IMG_W)
+
+    def test_empty_bbox_raises_valueerror(self):
+        """`[[]]` is malformed per docstring contract."""
+        with pytest.raises(ValueError, match="bbox 1 must have exactly 4 elements, got 0"):
+            _validate(None, [[]], IMG_H, IMG_W)
+
+    @pytest.mark.parametrize(
+        "wrong_len_bbox,expected_count",
+        [
+            pytest.param([1, 2], 2, id="two-elements"),
+            pytest.param([1, 2, 3], 3, id="three-elements"),
+            pytest.param([1, 2, 3, 4, 5], 5, id="five-elements"),
+        ],
+    )
+    def test_wrong_length_bbox_raises_valueerror(self, wrong_len_bbox, expected_count):
+        with pytest.raises(
+            ValueError,
+            match=rf"bbox 1 must have exactly 4 elements, got {expected_count}",
+        ):
+            _validate(None, [wrong_len_bbox], IMG_H, IMG_W)
+
+
+# ---------------------------------------------------------------------------
+# Per-coordinate type errors
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidCoordinateTypes:
+    @pytest.mark.parametrize(
+        "non_int_coord",
+        [
+            pytest.param(1.5, id="float"),
+            pytest.param([1], id="list"),
+            pytest.param({"x": 1}, id="dict"),
+            pytest.param(None, id="None"),
+        ],
+    )
+    def test_non_int_coord_raises_typeerror(self, non_int_coord):
+        """Non-integer-family coordinates (floats, containers, None) rejected."""
+        with pytest.raises(TypeError, match="must be integers"):
+            _validate(None, [[non_int_coord, 10, 10, 10]], IMG_H, IMG_W)
+
+    @pytest.mark.parametrize(
+        "string_float",
+        [
+            pytest.param("1.0", id="plain-decimal"),
+            pytest.param("1.5e3", id="decimal-scientific"),
+            pytest.param("1e10", id="pure-scientific"),
+        ],
+    )
+    def test_string_float_coord_raises_typeerror(self, string_float):
+        """Strings containing '.' or 'e' are rejected as string-floats."""
+        with pytest.raises(TypeError, match="string-float"):
+            _validate(None, [[string_float, 10, 10, 10]], IMG_H, IMG_W)
+
+    def test_non_numeric_string_raises_typeerror(self):
+        """
+        A string with no '.' or 'e' attempts int() conversion and fails,
+        surfacing as TypeError via the except-re-raise path.
+        """
+        with pytest.raises(TypeError, match="must be integers or string-integers"):
+            _validate(None, [["abc", 10, 10, 10]], IMG_H, IMG_W)
+
+
+# ---------------------------------------------------------------------------
+# Width/height value errors
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidDimensions:
+    @pytest.mark.parametrize("w", [0, -5, -100])
+    def test_non_positive_width_raises_valueerror(self, w):
+        with pytest.raises(ValueError, match=r"width \(.+\) must be > 0"):
+            _validate(None, [[10, 10, w, 10]], IMG_H, IMG_W)
+
+    @pytest.mark.parametrize("h", [0, -5, -100])
+    def test_non_positive_height_raises_valueerror(self, h):
+        with pytest.raises(ValueError, match=r"height \(.+\) must be > 0"):
+            _validate(None, [[10, 10, 10, h]], IMG_H, IMG_W)
+
+
+# ---------------------------------------------------------------------------
+# Out-of-bounds coordinate errors
+# ---------------------------------------------------------------------------
+
+
+class TestOutOfBounds:
+    @pytest.mark.parametrize(
+        "x,y",
+        [
+            pytest.param(-1, 10, id="negative-x"),
+            pytest.param(10, -1, id="negative-y"),
+            pytest.param(IMG_W, 10, id="x-equals-image-width"),
+            pytest.param(10, IMG_H, id="y-equals-image-height"),
+            pytest.param(IMG_W + 10, 10, id="x-beyond-width"),
+            pytest.param(10, IMG_H + 10, id="y-beyond-height"),
+        ],
+    )
+    def test_top_left_out_of_bounds_raises_valueerror(self, x, y):
+        """Top-left corner must satisfy 0 <= x < image_w AND 0 <= y < image_h."""
+        with pytest.raises(ValueError, match="top-left .+ out of bounds"):
+            _validate(None, [[x, y, 10, 10]], IMG_H, IMG_W)
+
+    def test_bbox_extends_beyond_image_width(self):
+        """x+w > image_w is rejected."""
+        with pytest.raises(ValueError, match="extends beyond image"):
+            _validate(None, [[100, 100, IMG_W, 10]], IMG_H, IMG_W)
+
+    def test_bbox_extends_beyond_image_height(self):
+        """y+h > image_h is rejected."""
+        with pytest.raises(ValueError, match="extends beyond image"):
+            _validate(None, [[100, 100, 10, IMG_H]], IMG_H, IMG_W)
+
+
+# ---------------------------------------------------------------------------
+# Index reporting for multi-bbox inputs
+# ---------------------------------------------------------------------------
+
+
+class TestErrorIndexing:
+    def test_error_reports_1indexed_position_of_invalid_bbox(self):
+        """First invalid bbox surfaces with its 1-indexed position in the error."""
+        bboxes = [
+            [0, 0, 10, 10],
+            [10, 10, 10, 10],
+            [20, 20, 10, 10],
+            [30, 30, 0, 10],  # 4th bbox: width = 0 → should raise
+        ]
+        with pytest.raises(ValueError, match=r"bbox 4 invalid: width"):
+            _validate(None, bboxes, IMG_H, IMG_W)


### PR DESCRIPTION
Covers every error branch of ConfigurableAugmentationPipeline._validate_bboxes — the COCO-format `[x, y, w, h]` validator rewritten in the ci-and-tests PR. Previously only the happy path was exercised (via test_pipeline_application); any regression in the error branches would reach a real training run silently.

Test classes (44 tests total):
- TestValidInputs                 (5): None, [], single, multiple, full-image,
                                       accepted coord types (str-ints, np ints)
- TestInvalidContainer            (5): non-list bboxes -> TypeError
- TestInvalidBboxElement          (8): non-list element / wrong length -> Type|Value
- TestInvalidCoordinateTypes      (8): float / container / None coords,
                                       string-float coords, non-numeric strings
- TestInvalidDimensions           (6): w <= 0 / h <= 0 -> ValueError
- TestOutOfBounds                 (8): top-left out of bounds,
                                       bbox extending beyond image
- TestErrorIndexing               (1): 1-indexed bbox position in error message

Validator is called statically with self=None — its body uses no instance state, so skipping a full pipeline construction keeps the tests fast (~8s cold) and isolated from albumentations state.

Riding along:
- TODOS.md: moved items 4 (pre-commit, merged via PR #26) and 10 (this PR) to a new ## Completed section. Item numbers preserved for reference stability. Added a status badge to item 5 (Dependabot) noting its PR is open on chore/dependabot. Updated item 12 to reference the new test file as a template for the P2 augmentation/ sub-roster.
- README: fixed pre-commit onboarding to include --extra lint — without it, `uv run --no-sync ruff check` fails because ruff is never installed into .venv. Confirmed by this PR when the pre-commit hooks refused to fire on commit.

Addresses TODOS.md item 10.