### PR TITLE
chore(merger): fix 3 mypy errors with Any annotations

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -202,55 +202,6 @@ Six items deferred during the `/plan-eng-review` of the CI/test infrastructure P
 
 ---
 
-### 13. Type-annotate `ml_engine/export/merger.py` — properly fix mypy errors instead of `# type: ignore`
-
-**What:** Resolve the three mypy errors in `ml_engine/export/merger.py` at the source (proper type annotations) rather than via `# type: ignore[operator]` band-aids:
-
-- Line 46: `peft_model.merge_and_unload()` — `"Tensor" not callable [operator]`. mypy infers `peft_model` (= `model.model`) as `Tensor` because `nn.Module.__getattr__` returns `Tensor | Module`, so the `.merge_and_unload()` call looks like calling a tensor.
-- Line 54: same root cause on the direct PEFT branch (`model.merge_and_unload()`).
-- Line 105: `checkpoint['metadata'].update(extra_metadata)` — `"Collection[Any]" has no attribute "update" [attr-defined]`. mypy widens the dict literal's value type to `Collection[Any]` (the common ancestor of `OrderedDict[str, Tensor]`, `list`, `dict`).
-
-**Why:** These errors fire on every commit that touches `ml_engine/export/packager.py` (which imports merger.py) because mypy follows the import graph. Without a real fix, every neighboring change either has to skip the mypy hook or sprinkle `# type: ignore` comments — both are noise. Cleaner to fix once.
-
-The pre-commit hook on the `test/p2-roster-export-distillation` branch (PR for TODOS item 12, export+distillation portion) was skipped via `SKIP=mypy` for exactly this reason. That bypass should not become a habit.
-
-**Pros:**
-- Restores mypy as a real lint gate for `ml_engine/export/`
-- Removes the "skip-mypy" precedent before it spreads to other modules
-- Forces clarity on the duck-typed PEFT shape that the merger relies on
-
-**Cons:**
-- Requires a `Protocol` definition for the PEFT-shape callable (`MergeAndUnloadable`) plus an explicit `cast(...)` or `assert hasattr(...)` to teach mypy the runtime check is sound
-- Annotating `checkpoint` as `Dict[str, Any]` is the easy half; the duck-typed PEFT bit needs the Protocol
-- ~30-60 min of mypy-aware refactoring
-
-**Context:** Surfaced when TODO #12's export tests landed and pre-commit's mypy hook flagged these on first commit touching `packager.py`. The errors are pre-existing baseline (predate ci-and-tests), but became an active blocker once pre-commit started running. Files in scope: `ml_engine/export/merger.py` only.
-
-Recommended approach (sketch):
-
-```python
-from typing import Any, Protocol, runtime_checkable, Dict, cast
-
-@runtime_checkable
-class _PeftMergeable(Protocol):
-    def merge_and_unload(self) -> nn.Module: ...
-
-def merge_lora_weights(model: nn.Module) -> nn.Module:
-    nested = getattr(model, "model", None)
-    if isinstance(nested, _PeftMergeable):
-        return nested.merge_and_unload()
-    if isinstance(model, _PeftMergeable):
-        return model.merge_and_unload()
-    logger.warning(...)
-    return model
-```
-
-For the checkpoint dict: `checkpoint: Dict[str, Any] = {...}` — explicit annotation tells mypy not to widen.
-
-**Depends on / blocked by:** None. Standalone cleanup.
-
----
-
 ## Completed
 
 Historical record of items that have shipped. Kept rather than deleted so external
@@ -289,3 +240,39 @@ because its body uses no instance state — `self` is only there because it's
 an instance method. Avoids constructing a full augmentation pipeline for
 every test. Fast (~8s cold for all 44 tests), isolated from albumentations
 state.
+
+### 13. Type-annotate `ml_engine/export/merger.py` ✅
+
+**Completed:** 2026-04-25 on `chore/mypy-merger-hygiene`, stacked on `ci/gate-ruff-checks`.
+
+**What shipped:** Three pre-existing mypy errors in `ml_engine/export/merger.py`
+fixed without `# type: ignore` band-aids:
+- Lines 46 + 54: `peft_model.merge_and_unload()` was flagged `"Tensor" not callable`
+  because `nn.Module.__getattr__` is typed `Tensor | Module` and mypy can't see
+  through PEFT's runtime delegation. Fix: rebind via `peft_model: Any = model.model`
+  (and `direct_peft: Any = model` on the direct branch) — local `Any` annotation
+  signals "trust the duck-typed runtime contract here, mypy can't help."
+- Line 105: `checkpoint["metadata"].update(extra_metadata)` was flagged because
+  mypy widened the dict literal to `Collection[Any]`. Fix: explicit
+  `checkpoint: Dict[str, Any] = {...}` annotation prevents the inference widening.
+
+**Why `Any` and NOT a Protocol:** the original sketch in this TODO proposed a
+`@runtime_checkable Protocol`. Investigation showed PEFT ships `py.typed` but
+`PeftModel.merge_and_unload` is exposed via `__getattr__` delegation to
+`self.base_model` (a `LoraModel`). mypy fundamentally cannot follow `__getattr__`
+for arbitrary attribute names — so even `from peft import PeftModel` and using
+`isinstance(x, PeftModel)` would NOT have helped. The Protocol approach would
+have worked but added 15 lines of new abstraction for a 3-line type fix. `Any`
+is honest about what's actually true: mypy can't help here, the runtime
+hasattr() checks ARE the contract.
+
+**The SKIP=mypy precedent:** This TODO existed because `SKIP=mypy git commit`
+became habitual across 5 PRs. With merger.py now mypy-clean, the bypass should
+no longer be needed for ml_engine/export/. (Other dirs still have baseline mypy
+errors covered by item 6 — broader cleanup.)
+
+**Design notes worth remembering:** before assuming a 3rd-party library's typing
+will solve a static-checking problem, verify it's not using `__getattr__`-based
+delegation. Many ML libraries (PEFT, transformers, accelerate) lean on dynamic
+composition and have similar gaps. `Any` at the boundary is a legitimate fix
+when the dynamic surface can't be statically modeled.

--- a/ml_engine/export/merger.py
+++ b/ml_engine/export/merger.py
@@ -34,15 +34,18 @@ def merge_lora_weights(model: nn.Module) -> nn.Module:
         >>> merged = merge_lora_weights(lora_model)
         >>> # merged is now a standard model, no PEFT dependency
     """
+    # `Any` annotation note: PEFT's `PeftModel` exposes `merge_and_unload`
+    # via __getattr__ delegation to `self.base_model` (a `LoraModel`). mypy
+    # cannot follow that delegation, so the call would fail static analysis
+    # even with `peft_model: PeftModel = ...`. The hasattr() checks above are
+    # the runtime contract; `Any` tells mypy "trust the duck-typing here."
+
     # Check if model has PEFT wrapper
     if hasattr(model, "model") and hasattr(model.model, "merge_and_unload"):
         # GroundingDINOLoRA wraps PEFT model in self.model
         logger.info("Merging LoRA weights into base model...")
 
-        # Get the PEFT model
-        peft_model = model.model
-
-        # Merge and unload - this modifies in place and returns unwrapped model
+        peft_model: Any = model.model
         merged_model = peft_model.merge_and_unload()
 
         logger.info("LoRA weights merged successfully")
@@ -51,7 +54,8 @@ def merge_lora_weights(model: nn.Module) -> nn.Module:
     if hasattr(model, "merge_and_unload"):
         # Direct PEFT model
         logger.info("Merging LoRA weights (direct PEFT model)...")
-        merged_model = model.merge_and_unload()
+        direct_peft: Any = model
+        merged_model = direct_peft.merge_and_unload()
         logger.info("LoRA weights merged successfully")
         return merged_model
 
@@ -90,8 +94,12 @@ def save_merged_model(
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Build checkpoint
-    checkpoint = {
+    # Build checkpoint. Explicit `Dict[str, Any]` annotation prevents mypy
+    # from inferring the dict literal's value type as `Collection[Any]` (the
+    # common ancestor of OrderedDict[str, Tensor], list, and dict). With the
+    # widened inference, `checkpoint["metadata"].update(extra_metadata)` would
+    # fail with `"Collection[Any]" has no attribute "update"`.
+    checkpoint: Dict[str, Any] = {
         "model_state_dict": model.state_dict(),
         "class_names": class_names or [],
         "metadata": {


### PR DESCRIPTION
Resolves the long-standing mypy errors in ml_engine/export/merger.py that have driven SKIP=mypy bypasses across 5 prior PRs.

Changes:
1. merge_lora_weights nested branch: rebind via `peft_model: Any = model.model`
2. merge_lora_weights direct branch: rebind via `direct_peft: Any = model` (different name to avoid mypy redefinition error in same scope)
3. save_merged_model: annotate `checkpoint: Dict[str, Any] = {...}` so the dict literal's value type doesn't widen to `Collection[Any]` (which doesn't have `.update`)

Why Any and NOT a Protocol (revised from this TODO's original sketch):

Investigation: PEFT ships `py.typed` and `LoraModel.merge_and_unload` is fully typed. BUT `PeftModel.merge_and_unload` works via `__getattr__` delegation to `self.base_model` (a `LoraModel`). mypy fundamentally cannot follow `__getattr__` for arbitrary attribute names. So even importing `from peft import PeftModel` would NOT have fixed our errors — mypy still wouldn't see the method. The Protocol approach would work (15 lines of new abstraction) but `Any` is honest about what's actually true here: the dynamic surface of PEFT can't be statically modeled, so the hasattr() checks ARE the contract.

This is a known structural gap in libraries that use heavy `__getattr__` delegation (PEFT, transformers, accelerate). Worth remembering before assuming a 3rd-party library's typing solves a problem.

Verification:
  uv run --no-sync mypy ml_engine/export/merger.py --ignore-missing-imports
  → Success: no issues found in 1 source file
  (was: Found 3 errors in 1 file)

  uv run --extra test --extra cpu pytest tests/unit/ml_engine/export/test_merger.py
  → 18 passed, 3 xfailed (no regressions; the test stubs duck-type the
    same shape the function expects)

  uv run --extra test --extra cpu pytest tests/unit tests/integration tests/contract \
    -m "not gpu and not slow" -n 4 --dist=loadscope
  → 1396 passed, 5 skipped, 8 xfailed (no regressions)

TODOS.md: moved item 13 from active list to Completed section with context preserved (the PEFT __getattr__ realization, the rejection of Protocol in favor of Any, the SKIP=mypy precedent now broken).

This is the FIRST commit in 5+ PRs where pre-commit's mypy hook should pass on staged files without SKIP=mypy. The bypass should no longer be routine for ml_engine/export/. Other directories still have baseline mypy errors covered by the broader item 6 cleanup.