### PR TITLE
chore(mypy): install types-PyYAML (Step 1) + file SAM LoRA TODO #14

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -94,19 +94,70 @@ Six items deferred during the `/plan-eng-review` of the CI/test infrastructure P
 
 ---
 
-### 6. Typed mypy overrides — remove `--ignore-missing-imports`
+### 6. mypy baseline cleanup — drive 416 errors to zero, then flip the gate
 
-**What:** Add `[[tool.mypy.overrides]]` blocks in `pyproject.toml` for untyped third-party deps (`groundingdino.*`, `segment_anything.*`, `peft.*`, `transformers.*`). Remove the workflow-level `--ignore-missing-imports` flag and `continue-on-error: true` from the mypy step.
+**Status:** Baseline measured 2026-04-25 — `uv run --no-sync mypy core ml_engine api --ignore-missing-imports` reports **410 errors in 50 files** (after Step 1 installed `types-PyYAML` and cleared 6 `yaml`-import errors). `continue-on-error: true` on the mypy step in `ci.yml` keeps CI passing while this baseline exists.
 
-**Why:** Current CI runs mypy lax during the 2-week ramp-up to avoid blocking on volume of existing errors. After ramp, tighten so mypy actually gates the build.
+**Step 1 outcome (shipped):** Installed `types-PyYAML` only. Surveyed our other third-party imports (PIL, tqdm, requests) — type stubs exist for those too, but installing them would NOT drop the count today: `--ignore-missing-imports` already suppresses errors for libraries without inline type info, and adding their stubs would START flagging code that uses them. That's a NET INCREASE in the visible baseline, not a decrease — wrong direction for a "quick win" PR. Those stubs should ride with the per-directory cleanup PRs (Step 2) when the related code is being touched anyway.
 
-**Pros:** Real type checking. Catches Optional[X] vs X bugs, wrong-shape dict returns, return-type drift. High value in ML code where tensor shapes rarely match docstrings.
+**Lesson learned:** the original Step-1 estimate of "100-150 errors from missing stubs" was wildly optimistic. Reality: 6. The `--ignore-missing-imports` flag turns out to be a sledgehammer that hides most stub gaps, so removing it would expose them — but removing it is exactly what Step 3 does. So the order doesn't matter much; what matters is committing to the multi-week cleanup or pivoting to alternative 3 (strict-on-critical-only).
 
-**Cons:** Will surface existing type violations that need cleanup. Unclear volume until lax mypy has run for ~2 weeks and the error count is measurable.
+**What:** Drive the mypy baseline to zero, then remove `continue-on-error: true` from the mypy step in `ci.yml` (mirror what item 9 + the gate-flip PR did for ruff). End state: mypy actually gates merges.
 
-**Context:** Workflow env currently sets `--ignore-missing-imports` globally. Replace with narrow per-package overrides. Start with untyped-but-stable packages (groundingdino, segment_anything); leave actively-upgrading packages (transformers) behind `ignore_missing_imports = true` for longer.
+**Why this is NOT a single PR:** unlike the ruff baseline (mostly mechanical whitespace + import order, ~90% auto-fixable), mypy errors require per-case judgment. Each one is a real type ambiguity:
 
-**Depends on / blocked by:** 2 weeks of running CI with lax mypy to establish baseline error count.
+| Error class | Example | Effort per fix |
+|---|---|---|
+| Missing 3rd-party stubs | `Library stubs not installed for "yaml"` | 1 line per dep — install `types-PyYAML` etc. |
+| Missing variable annotations | `Need type annotation for "annotation_counts"` | 1 line per variable |
+| `Optional` mishandling | `Argument 1 to "Path" has incompatible type "str \| None"` | Per-case judgment (assert non-None? refactor signature? change caller?) |
+| Variable shadowing | `path: str = ...; path = Path(path)` rebinds incompatibly | Rename or refactor |
+| Subclass narrowing | `formatter: ColoredTextFormatter = TextFormatter(...)` | Often signals real type design issues |
+| Library `__getattr__` (PEFT pattern) | What item 13 fixed in `merger.py` | Case-by-case `Any` cast |
+
+**Honest scope estimate (~2-3 weeks of focused work):**
+- ~100-150 errors are quick wins (install stubs, add obvious annotations) — ~1 hour
+- ~150-200 are mechanical per-case (variable shadowing, simple Optional, missing return types) — half-day per directory
+- ~50-100 require real semantic work (Optional refactor, type-narrowing assertions) — case-by-case
+
+**Recommended sequencing (mirrors item 9's per-directory rollout, ~6 PRs total):**
+
+```
+Step 1 (1 PR, ~1 hr):
+  deps: install missing type stubs (types-PyYAML, types-Pillow,
+  types-requests, pandas-stubs, etc.) into the lint extra.
+  Drops baseline by ~25-100 errors immediately. Zero runtime risk.
+
+Step 2 (4 PRs, ~half-day each):
+  mypy-baseline-core/        (~10 errors)
+  mypy-baseline-api/         (~20-30 estimated)
+  mypy-baseline-augmentation/ (?)
+  mypy-baseline-ml-engine/   (bulk; may need sub-PR splits like ruff did)
+
+Step 3 (1 PR, 1 line):
+  ci(mypy): flip continue-on-error → false in ci.yml's mypy step
+  (mirrors what ci/gate-ruff-checks did for ruff)
+```
+
+**Three pragmatic alternatives if 2-3 weeks doesn't justify the ROI:**
+
+1. **Full strict (the path above)** — multi-week effort, ongoing per-PR cost to maintain types. Worth it if type bugs have been biting in production.
+2. **Pragmatic non-gating** — keep mypy advisory forever, fix specific high-value modules opportunistically. The status quo. Costs nothing now; defers all benefits.
+3. **Strict only on critical modules** — flip mypy to gating ONLY for `core/` (config, logging) and `api/schemas.py` (request/response wire format). Keep `ml_engine/` and others advisory. **~1 PR of work**, captures most of the bug-prevention value with minimal cleanup overhead. Rationale: type discipline matters most where (a) the wire format is defined and (b) other modules import from. ML training internals tend to fail "math is wrong" not "dict had unexpected key" — mypy doesn't help with the former anyway.
+
+**Pros (of full strict):** Real type checking. Catches Optional[X] vs X bugs, wrong-shape dict returns, return-type drift. High value in ML code where tensor shapes rarely match docstrings.
+
+**Cons:** 416 existing errors require per-file judgment work. Ongoing per-PR cost to maintain types. ML libraries (PEFT, transformers, accelerate) use heavy `__getattr__` delegation that mypy can't model — `Any` casts will be needed at boundaries even after cleanup (item 13 documented this for PEFT).
+
+**Recommended next action: DECIDE.** Step 1 is done — the post-stubs baseline is 410 errors in 50 files, only marginally better than 416/53. The "missing stubs" surface turned out to be tiny. Now choose:
+
+- **Path A (full strict)** — commit to ~2-3 weeks of per-directory cleanup PRs (Step 2) followed by the gate flip (Step 3). Worth it if type bugs have been biting in production.
+- **Path B (status quo)** — leave mypy advisory forever; fix high-value modules opportunistically. Costs nothing now; defers all benefits.
+- **Path C (strict-on-critical-only — recommended)** — flip mypy to gating ONLY for `core/` (config, logging) and `api/schemas.py` (request/response wire format). Keep `ml_engine/` and others advisory. ~1 PR of work; captures most of the bug-prevention value with minimal cleanup overhead.
+
+Step 2 ought to wait until this decision is made — kicking off per-directory cleanup PRs without knowing the end state is wasted work.
+
+**Depends on / blocked by:** the A/B/C decision above. None of the steps below it block each other.
 
 ---
 
@@ -199,6 +250,38 @@ Six items deferred during the `/plan-eng-review` of the CI/test infrastructure P
 **Context:** Deferred from the original ci-and-tests PR (~3400 lines new) to keep that PR shippable. PR is CI-green at 52% combined coverage, merged with COVERAGE_MIN ratchet seeded at 50. Each new test file from this roster bumps real coverage and unlocks a COVERAGE_MIN bump in the same PR.
 
 **Depends on / blocked by:** `ci-and-tests` PR merging (for the test infrastructure and markers). No other blockers. Recommended sequencing: look at `tests/unit/augmentation/test_augmentation_factory.py` (shipped in item 10) for the pytest-parametrize + class-grouping pattern when adding the augmentation/ tests in this item.
+
+---
+
+### 14. `tests/test_sam_lora.py` — 13 pre-existing failures + a CI scope gap
+
+**What:** Investigate and resolve 13 pre-existing test failures in `tests/test_sam_lora.py`. Discovered 2026-04-25 while running the full `pytest tests` (vs the narrower `pytest tests/unit tests/integration tests/contract` that CI runs). Verified pre-existing via `git stash` against `agentic`'s baseline — NOT introduced by any PR in this work stream.
+
+**Sample failures (concrete signal for the investigator):**
+- `TestSAMHQLoRAConfig::test_lora_target_modules_format` — asserts `'q_proj' in target_modules` but actual `target_modules` is `['qkv', 'proj']`. Either the target-module naming changed (and the test wasn't updated), OR there's a real regression in `ml_engine/models/teacher/sam_lora.py`.
+- `TestSAMHQLoRAForwardPass::test_forward_returns_expected_keys` — expected output shape `(2, 3, 256, 256)`, got `(2, 3, 1024, 1024)`. Indicates either the SAM forward pass was rewritten to return native 1024-resolution masks (without updating the test) OR the test was wrong from the start.
+
+**Why this needs attention:**
+1. **Real bug vs stale test** — both interpretations have evidence. Either way, the truth needs to be established. If real bug: `sam_lora.py` is silently broken in production. If stale test: confusing signal whenever someone runs the test file directly.
+2. **CI scope gap** — `tests/test_sam_lora.py` is a root-level test file (`tests/*.py`) that CI's `pytest tests/unit tests/integration tests/contract` never picks up. So these failures have been invisible to CI for as long as they've existed. CI was designed to skip root-level tests intentionally (item 11 of the ci-and-tests design doc lists root-level files as "audit for staleness — `test_data_manager.py`, `test_sam_lora.py`, `test_auto_labeler.py`"), but the audit never finished. This is the unfinished half of that audit.
+
+**Pros:**
+- Resolves a real signal/noise problem (right now nobody knows if these are bugs)
+- Closes the CI scope gap — either delete dead tests or move them under `tests/unit/` so CI runs them
+- May reveal an actual production bug in SAM-HQ LoRA wrapper
+
+**Cons:**
+- Investigation requires understanding SAM-HQ LoRA internals (target_modules, forward pass shape contract)
+- If the tests turn out to be stale, deletion + reasoning needs to be documented
+- If a real bug is found, the fix may be deeper than expected (LoRA adapter shape contract changes are usually invasive)
+
+**Context:** The 3 root-level tests in `tests/` are: `test_sam_lora.py`, `test_data_manager.py`, `test_auto_labeler.py`. The ci-and-tests design doc explicitly flagged these as "audit for staleness" but didn't follow through. Same investigation should cover all three. Suggested minimal path:
+
+1. Run each root-level test file with verbose pytest (`-v --tb=long`). Cluster failures.
+2. For each cluster, decide: real bug → file separately + fix; stale test → delete with one-line PR commit explaining why; outdated assumption → update the test.
+3. After per-file decisions: either move the file under `tests/unit/` (so CI catches future regressions) or delete it.
+
+**Depends on / blocked by:** None. Independent of in-flight work.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,12 @@ test = [
 lint = [
     "ruff",
     "mypy",
+    # Type stubs for runtime deps that lack inline `py.typed` markers.
+    # Adding only stubs that DROP the current mypy baseline; stubs for libs
+    # that --ignore-missing-imports currently suppresses (PIL/tqdm/requests)
+    # would surface previously-hidden errors and should ride with item 6's
+    # broader cleanup, not this Step-1 quick-win PR.
+    "types-PyYAML",
 ]
 # Torch variant flag extras. Mutually exclusive — uv enforces via the
 # `[tool.uv] conflicts` block below. One of these must be selected at

--- a/uv.lock
+++ b/uv.lock
@@ -514,6 +514,7 @@ gpu = [
 lint = [
     { name = "mypy" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 onnx = [
     { name = "onnx" },
@@ -584,6 +585,7 @@ requires-dist = [
     { name = "torchvision", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "grounded-segment-anything", extra = "cpu" } },
     { name = "tqdm", specifier = ">=4.60.0" },
     { name = "transformers", specifier = ">=4.40.0,<5.0.0" },
+    { name = "types-pyyaml", marker = "extra == 'lint'" },
     { name = "ultralytics", specifier = ">=8.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.22.0" },
     { name = "websockets", specifier = ">=11.0" },
@@ -2306,6 +2308,15 @@ version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/65/3ffa90e158a2c82f0716eee8d26a725d241549b7d7aaf7e4f44ac03ebd89/triton-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3e54983cd51875855da7c68ec05c05cf8bb08df361b1d5b69e05e40b0c9bd62", size = 253090354, upload-time = "2025-01-22T19:12:21.872Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two related TODOS housekeeping changes shipped together because both emerged from the same investigation pass.

1. mypy Step 1 — install types-PyYAML stubs (TODOS item 6)

   The original Step-1 estimate said "100-150 errors come from missing stubs, 1 hour to install." Reality after surveying our imports + the `--ignore-missing-imports` interaction:

   - Only `yaml` triggered a "Library stubs not installed" warning, hit across 6 files (core/config.py + 5 ml_engine/ files).
   - Other potentially-stubbed deps (PIL, tqdm, requests) are silenced by `--ignore-missing-imports`. Adding their stubs would START flagging usages — net INCREASE in the visible baseline, not a decrease. Wrong direction for a quick-win PR.

   Added `types-PyYAML` only. Baseline drop:
     Before: 416 errors in 53 files After:  410 errors in 50 files (-6 errors, -3 fully-clean files)

   Tracked the lesson in TODOS.md item 6 — the original estimate was
   wildly optimistic, the post-Step-1 inflection point now belongs to
   the Path A/B/C decision (full strict / status quo / strict-on-
   critical-only). Step 2 (per-directory cleanup) should NOT begin
   until that decision is made.

2. New TODO item 14 — `tests/test_sam_lora.py` 13 pre-existing failures

   Discovered while running the full `pytest tests` suite (vs the narrower `tests/unit + integration + contract` that CI runs). Verified pre-existing via `git stash` against agentic's baseline — not caused by any PR in this work stream.

   Two concrete failures captured for the next investigator:
   - target_modules format mismatch: test expects `q_proj`, code produces `qkv`/`proj`. Either real bug (LoRA wrapper regression) or stale test (target naming changed without test update).
   - Forward-pass shape mismatch: expected (2,3,256,256), got (2,3,1024,1024). Either real bug (output resolution drift) or stale test (SAM was rewritten to return native 1024 masks).

   The CI scope gap: `tests/test_sam_lora.py` is a root-level test
   file. CI runs `tests/unit + integration + contract` only — these
   root-level tests have been invisible to CI for as long as they've
   existed. The ci-and-tests design doc explicitly listed root-level
   files (sam_lora, data_manager, auto_labeler) for staleness audit
   but the audit never finished. Item 14 is the unfinished half.

Verification:
  uv run --no-sync mypy core ml_engine api --ignore-missing-imports
    → Found 410 errors in 50 files (was 416 in 53)

  uv run --extra test --extra cpu pytest tests/unit tests/integration tests/contract \
    -m "not gpu and not slow" -n 4 --dist=loadscope
    → 1396 passed, 5 skipped, 8 xfailed (no regressions)

This is the second PR in the series where pre-commit's mypy hook should pass without SKIP=mypy (after item 13's fix in merger.py). The mypy bypass should no longer be routine for ml_engine/export/ or for files this PR touches.