### PR TITLE
chore(mypy): clean core/ baseline (Step 2.1 of TODOS #6) — 10 errors → 0

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -96,7 +96,19 @@ Six items deferred during the `/plan-eng-review` of the CI/test infrastructure P
 
 ### 6. mypy baseline cleanup — drive 416 errors to zero, then flip the gate
 
-**Status:** Baseline measured 2026-04-25 — `uv run --no-sync mypy core ml_engine api --ignore-missing-imports` reports **410 errors in 50 files** (after Step 1 installed `types-PyYAML` and cleared 6 `yaml`-import errors). `continue-on-error: true` on the mypy step in `ci.yml` keeps CI passing while this baseline exists.
+**Status:** Path A chosen 2026-04-25 — committed to driving the baseline to zero across all maintained directories.
+
+**Live baseline:** **400 errors in 48 files** (after Step 1 stubs + Step 2 core/ — see progress below).
+
+`continue-on-error: true` on the mypy step in `ci.yml` keeps CI passing while this baseline exists. Step 3 flips that off after Step 2 finishes.
+
+**Progress:**
+- ✅ Step 1: installed `types-PyYAML` (cleared 6 yaml errors). Baseline 416 → 410.
+- ✅ Step 2.1: `core/` clean — 4 functions in `config.py` widened `path: str` → `path: str | Path`; 2 formatter locals in `logging_config.py` annotated as base `logging.Formatter`. Baseline 410 → 400.
+- ⬜ Step 2.2: `api/` (estimated ~30-50 own errors)
+- ⬜ Step 2.3: `augmentation/` (estimated ~25-50 own errors)
+- ⬜ Step 2.4: `ml_engine/` (the bulk; will need sub-PR splits like ruff cleanup did)
+- ⬜ Step 3: flip `continue-on-error` → false in ci.yml's mypy step
 
 **Step 1 outcome (shipped):** Installed `types-PyYAML` only. Surveyed our other third-party imports (PIL, tqdm, requests) — type stubs exist for those too, but installing them would NOT drop the count today: `--ignore-missing-imports` already suppresses errors for libraries without inline type info, and adding their stubs would START flagging code that uses them. That's a NET INCREASE in the visible baseline, not a decrease — wrong direction for a "quick win" PR. Those stubs should ride with the per-directory cleanup PRs (Step 2) when the related code is being touched anyway.
 
@@ -149,15 +161,15 @@ Step 3 (1 PR, 1 line):
 
 **Cons:** 416 existing errors require per-file judgment work. Ongoing per-PR cost to maintain types. ML libraries (PEFT, transformers, accelerate) use heavy `__getattr__` delegation that mypy can't model — `Any` casts will be needed at boundaries even after cleanup (item 13 documented this for PEFT).
 
-**Recommended next action: DECIDE.** Step 1 is done — the post-stubs baseline is 410 errors in 50 files, only marginally better than 416/53. The "missing stubs" surface turned out to be tiny. Now choose:
+**Recommended next action: continue Step 2.** Path A is the chosen direction. Next is `mypy-baseline-api/` (estimated ~30-50 errors). Use the same per-case judgment that worked for `core/`:
+- Path-as-string parameter pattern → widen to `str | Path`
+- Subclass-narrowing pattern → annotate as base type
+- Variable shadowing → rename or refactor
+- Truly intractable cases (PEFT-like `__getattr__` delegation) → `Any` cast at boundary, with comment
 
-- **Path A (full strict)** — commit to ~2-3 weeks of per-directory cleanup PRs (Step 2) followed by the gate flip (Step 3). Worth it if type bugs have been biting in production.
-- **Path B (status quo)** — leave mypy advisory forever; fix high-value modules opportunistically. Costs nothing now; defers all benefits.
-- **Path C (strict-on-critical-only — recommended)** — flip mypy to gating ONLY for `core/` (config, logging) and `api/schemas.py` (request/response wire format). Keep `ml_engine/` and others advisory. ~1 PR of work; captures most of the bug-prevention value with minimal cleanup overhead.
+If a particular file proves harder than expected, file a sub-TODO and move on. Don't let one stubborn file block the whole rollout.
 
-Step 2 ought to wait until this decision is made — kicking off per-directory cleanup PRs without knowing the end state is wasted work.
-
-**Depends on / blocked by:** the A/B/C decision above. None of the steps below it block each other.
+**Depends on / blocked by:** none. Step 2.2/2.3/2.4 don't block each other; can be done in any order or even in parallel.
 
 ---
 

--- a/core/config.py
+++ b/core/config.py
@@ -17,7 +17,7 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
-def load_config(config_path: str) -> Dict[str, Any]:
+def load_config(config_path: str | Path) -> Dict[str, Any]:
     """
     Load configuration from YAML file.
 
@@ -43,7 +43,7 @@ def load_config(config_path: str) -> Dict[str, Any]:
     return config
 
 
-def save_config(config: Dict[str, Any], output_path: str) -> None:
+def save_config(config: Dict[str, Any], output_path: str | Path) -> None:
     """
     Save configuration to YAML file.
 
@@ -64,7 +64,7 @@ def save_config(config: Dict[str, Any], output_path: str) -> None:
     logger.info("Saved config to: %s", output_path)
 
 
-def load_json(json_path: str) -> Dict[str, Any]:
+def load_json(json_path: str | Path) -> Dict[str, Any]:
     """
     Load JSON file.
 
@@ -85,7 +85,7 @@ def load_json(json_path: str) -> Dict[str, Any]:
     return data
 
 
-def save_json(data: Dict[str, Any], output_path: str) -> None:
+def save_json(data: Dict[str, Any], output_path: str | Path) -> None:
     """Save data to JSON file."""
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -98,7 +98,11 @@ def configure_logging(
     if format_type.lower() == FORMAT_TYPE_JSON:
         formatter = JSONFormatter()
     else:
-        # Use colored formatter for console if TTY detected
+        # `console_formatter` is annotated as the base `logging.Formatter` so
+        # mypy doesn't narrow the type to whichever branch's class is assigned
+        # first (ColoredTextFormatter and TextFormatter are sibling subclasses
+        # of logging.Formatter, not in a subclass relationship to each other).
+        console_formatter: logging.Formatter
         if sys.stdout.isatty():
             console_formatter = ColoredTextFormatter()
         else:
@@ -209,7 +213,10 @@ def get_job_logger(job_id: str, output_dir: str, name: str = "training") -> logg
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     log_file = log_dir / f"{name}_{timestamp}.log"
 
-    # Create formatter with job context
+    # Create formatter with job context. Annotated as the base `logging.Formatter`
+    # so mypy accepts both branch assignments (JSONFormatter vs TextFormatter are
+    # sibling subclasses, not in a subclass relationship).
+    formatter: logging.Formatter
     if format_type.lower() == FORMAT_TYPE_JSON:
         formatter = JSONFormatter(extra_fields={"job_id": job_id})
     else:


### PR DESCRIPTION
This PR is Step 2.1 — the core/ portion of the per-directory cleanup.

Two patterns, both textbook fixes:

1. core/config.py — `path: str` parameter rebound to Path

   load_config, save_config, load_json, save_json each declared their
   path parameter as `str` then immediately did `path = Path(path)`
   internally. mypy correctly flagged the rebind ("Path not assignable
   to str") and the subsequent .exists()/.parent calls on the now-Path
   variable that mypy still thought was str.

   Fix: widen the parameter type to `str | Path` (Python 3.10 PEP 604
   union syntax). Backward-compatible — all current callers pass strings;
   forward-flexible — callers can now pass Path objects directly.
   Internal `path = Path(path)` now narrows from `str | Path` to `Path`,
   subsequent attribute accesses are valid.

2. core/logging_config.py — sibling-subclass formatter narrowing

   `console_formatter` and `formatter` were each assigned different subclasses of `logging.Formatter` in if/else branches: console_formatter = ColoredTextFormatter() if sys.stdout.isatty() else TextFormatter() formatter = JSONFormatter(...) if format_type == "json" else TextFormatter(...)

   ColoredTextFormatter and TextFormatter are sibling subclasses (not in each other's MRO), and same for JSONFormatter vs TextFormatter — mypy narrowed to whichever class was assigned first, then complained about the other branch.

   Fix: explicit annotation `console_formatter: logging.Formatter` (and `formatter: logging.Formatter`) widens the variable type so both branch assignments are valid.

Verification:
  uv run --no-sync mypy core --ignore-missing-imports
    → Success: no issues found in 6 source files
    (was: Found 10 errors in 2 files)

  uv run --no-sync mypy core ml_engine api --ignore-missing-imports
    → Found 400 errors in 48 files
    (was: 410 errors in 50 files)

  uv run --extra test --extra cpu pytest tests/unit tests/integration tests/contract \
    -m "not gpu and not slow" -n 4 --dist=loadscope
    → 1396 passed, 5 skipped, 8 xfailed (no regressions)

TODOS.md item 6 updated:
- Status: Path A chosen, live baseline 400/48
- Step 2.1 (core/) marked done with brief notes on the two patterns
- Recommended next action: Step 2.2 (api/) — same per-case judgment
- Future Step 2.x branches (api, augmentation, ml_engine) can ship in any order, including in parallel — they don't block each other.

This is the third PR in the series where pre-commit's mypy hook passes on staged files without SKIP=mypy (after item 13's merger fix and the stubs PR). For files in core/ + ml_engine/export/, the bypass should no longer be needed at all.