### PR TITLE
feat(lineage): plumb job_id through training pipeline so artifact manifests carry real lineage

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -353,7 +353,13 @@ Then the route's main loop becomes `async for event in _subscribe_to_events(...)
 
 ---
 
-### 16. Plumb `job_id` through training pipeline so artifact manifests carry real lineage (revert Optional schemas)
+### 16. Plumb `job_id` through training pipeline so artifact manifests carry real lineage (revert Optional schemas) ✅
+
+**Completed:** 2026-04-27 on `feat/job-id-lineage-plumbing`. (Original entry below for context.)
+
+**What shipped:** `job_id` now flows from `_job_entry_point` → `JobHandler.run()` → `Trainer.__init__` → `BaseModelTrainer.__init__` → `CreateByInfo` and `BundleManifest.lineage`. For experiment trials, `TrialRunner.run()` composes `f"{job_id}/{trial_id}"` (e.g. `"job-abc/trial_003"`) before passing into the trial subprocess so per-trial manifests are uniquely identifiable while still tracing back to the parent experiment job. `CreateByInfo.job_id` and `BundleManifest.lineage` reverted from `Optional[str]` back to `str` / `Dict[str, str]`. New `tests/unit/ml_engine/test_lineage.py` (16 tests) pins the contract: handler signatures must accept `job_id`, the trial subprocess's first positional arg is `composed_job_id`, schema types are non-Optional, manifest save/load roundtrip preserves the value verbatim.
+
+---
 
 **What:** Thread `job_id` from `_job_entry_point` (where it already exists) all the way down to `BaseModelTrainer.save_adapters()` and `Trainer._save_adapters()`. Then revert `CreateByInfo.job_id` and `BundleManifest.lineage` in `ml_engine/artifacts/schemas.py` from `Optional[str]` back to `str`/`Dict[str, str]` (their current Optional widening is a marker for this gap, not a desired type).
 

--- a/ml_engine/artifacts/schemas.py
+++ b/ml_engine/artifacts/schemas.py
@@ -34,15 +34,16 @@ class BaseModelRef:
 
 @dataclass
 class CreateByInfo:
-    """Information about who created the artifact"""
+    """Information about who created the artifact.
 
-    # TODO #16: revert to `job_id: str` once the plumbing lands. Optional
-    # is a marker for the gap: the trainer (called via subprocess_runner)
-    # doesn't propagate the parent job_id down to model_trainers/base.py
-    # at adapter-save time, so manifests written from training currently
-    # have job_id=None. Manifests written by other paths (tests, post-hoc
-    # tools) supply the real id.
-    job_id: Optional[str]
+    job_id flows down from the JobHandler through Trainer/BaseModelTrainer
+    to save_adapters() — see ml_engine/jobs/handlers/base.py:JobHandler.run.
+    For experiment trials, the value is composed as `f"{job_id}/{trial_id}"`
+    in trial_runner.py so manifests can be traced back to both the parent
+    experiment job and the specific trial.
+    """
+
+    job_id: str
     timestamp: str
 
 
@@ -79,10 +80,9 @@ class BundleManifest:
     # model_name -> relative path (from where bundle.manifest.json lives) of
     # the corresponding adapter.manifest.json.
     artifacts: Dict[str, str]
-    # TODO #16: revert to `Dict[str, str]` once the plumbing lands.
-    # Optional[str] mirrors CreateByInfo.job_id above — the trainer doesn't
-    # currently propagate job_id down to bundle save, so values can be None.
-    lineage: Dict[str, Optional[str]]  # "job_id"
+    # {"job_id": "..."} populated by Trainer._save_adapters from
+    # self.job_id (forwarded from the JobHandler). See CreateByInfo above.
+    lineage: Dict[str, str]  # "job_id"
     merged_checkpoints: Optional[Dict[str, str]] = None  # model_naem -> relative path of merged model
 
     def save(self, path: Path) -> None:

--- a/ml_engine/experiment/loop.py
+++ b/ml_engine/experiment/loop.py
@@ -75,6 +75,7 @@ class ExperimentLoop:
 
     def run(
         self,
+        job_id: str,
         data_manager,
         output_dir: str,
         budget: ExperimentBudget,
@@ -167,6 +168,7 @@ class ExperimentLoop:
             }
 
             result: TrialResult = runner.run(
+                job_id=job_id,
                 data_manager=data_manager,
                 overrides=effective_overrides,
                 base_output_dir=output_dir,

--- a/ml_engine/experiment/trial_runner.py
+++ b/ml_engine/experiment/trial_runner.py
@@ -36,6 +36,7 @@ _PRIMARY_METRIC_KEY = "val_mAP50"
 
 
 def _trial_subprocess(
+    composed_job_id: str,
     data_manager,
     config: Dict[str, Any],
     output_dir: str,
@@ -44,7 +45,13 @@ def _trial_subprocess(
     cancel_event: MpEvent,
     primary_metric_key: str = _PRIMARY_METRIC_KEY,
 ) -> None:
-    """Entry point for per-trial subprocess."""
+    """Entry point for per-trial subprocess.
+
+    composed_job_id has the form `f"{parent_job_id}/{trial_id}"` (e.g.
+    "job-abc/trial_003") so artifact manifests written by the trial's
+    Trainer can be traced back to both the parent experiment job AND the
+    specific trial that produced them. See TODO #16 in TODOS.md.
+    """
     import sys as _sys
     from pathlib import Path as _Path
 
@@ -66,6 +73,7 @@ def _trial_subprocess(
 
     try:
         trainer = Trainer(
+            job_id=composed_job_id,
             data_manager=data_manager,
             output_dir=output_dir,
             config=config,
@@ -137,6 +145,7 @@ class TrialRunner:
 
     def run(
         self,
+        job_id: str,
         data_manager,
         overrides: Dict[str, Any],
         base_output_dir: str,
@@ -155,6 +164,10 @@ class TrialRunner:
         4. Return TrialResult
 
         Args:
+            job_id: Parent experiment job's id. Composed as
+                f"{job_id}/{trial_id}" before being passed into the trial
+                subprocess so artifact manifests carry both the parent and
+                the per-trial identifier (TODO #16 plumbing).
             data_manager: DataManager instance.
             overrides: Config overrides (dotted or nested dict), validated by ExperimentLoop.
             base_output_dir: Parent dir; trial output goes in {base_output_dir}/{trial_id}/.
@@ -167,6 +180,10 @@ class TrialRunner:
 
         trial_id = trial_id or f"trial_{uuid.uuid4().hex[:8]}"
         trial_output_dir = str(Path(base_output_dir) / trial_id)
+        # Composed id flows into the trial subprocess and ends up as the
+        # job_id field on every artifact manifest written by the trial's
+        # Trainer.
+        composed_job_id = f"{job_id}/{trial_id}"
 
         logger.info("Trial %s starting (overrides=%s)", trial_id, list(overrides.keys()))
         t0 = time.monotonic()
@@ -183,6 +200,7 @@ class TrialRunner:
         proc = ctx.Process(
             target=_trial_subprocess,
             args=(
+                composed_job_id,
                 data_manager,
                 config,
                 trial_output_dir,

--- a/ml_engine/jobs/handlers/auto_label.py
+++ b/ml_engine/jobs/handlers/auto_label.py
@@ -24,6 +24,7 @@ class AutoLabelHandler(JobHandler):
 
     def run(
         self,
+        job_id: str,
         job_config: Dict[str, Any],
         output_dir: str,
         progress_queue: mp.Queue,

--- a/ml_engine/jobs/handlers/base.py
+++ b/ml_engine/jobs/handlers/base.py
@@ -38,6 +38,7 @@ class JobHandler(ABC):
     @abstractmethod
     def run(
         self,
+        job_id: str,
         job_config: Dict[str, Any],
         output_dir: str,
         progress_queue: mp.Queue,
@@ -53,6 +54,10 @@ class JobHandler(ABC):
         when the process exits.
 
         Args:
+            job_id: ID of the job that triggered this run. Required for
+                lineage in artifact manifests (CreateByInfo.job_id /
+                BundleManifest.lineage). Forwarded by subprocess_runner
+                from the parent JobManager.
             job_config: Job configuration dictionary
             output_dir: Output directory for job artifacts
             progress_queue: Queue to send progress updates (non-blocking put)

--- a/ml_engine/jobs/handlers/distillation.py
+++ b/ml_engine/jobs/handlers/distillation.py
@@ -33,6 +33,7 @@ class StudentDistillationHandler(JobHandler):
 
     def run(
         self,
+        job_id: str,
         job_config: Dict[str, Any],
         output_dir: str,
         progress_queue: mp.Queue,

--- a/ml_engine/jobs/handlers/experiment_loop.py
+++ b/ml_engine/jobs/handlers/experiment_loop.py
@@ -52,6 +52,7 @@ class ExperimentLoopHandler(JobHandler):
 
     def run(
         self,
+        job_id: str,
         job_config: Dict[str, Any],
         output_dir: str,
         progress_queue: mp.Queue,
@@ -143,8 +144,12 @@ class ExperimentLoopHandler(JobHandler):
             return cancel_event.is_set()
 
         # --- Run ---
+        # job_id flows down to per-trial subprocesses where it's composed
+        # as f"{job_id}/{trial_id}" before being recorded in artifact
+        # manifests (TODO #16 plumbing).
         loop = ExperimentLoop(guard=guard)
         result = loop.run(
+            job_id=job_id,
             data_manager=data_manager,
             output_dir=output_dir,
             budget=budget,

--- a/ml_engine/jobs/handlers/teacher.py
+++ b/ml_engine/jobs/handlers/teacher.py
@@ -25,6 +25,7 @@ class TeacherTrainingHandler(JobHandler):
 
     def run(
         self,
+        job_id: str,
         job_config: Dict[str, Any],
         output_dir: str,
         progress_queue: mp.Queue,
@@ -81,8 +82,11 @@ class TeacherTrainingHandler(JobHandler):
         def cancel_check() -> bool:
             return cancel_event.is_set()
 
-        # Create and run trainer
+        # Create and run trainer. job_id is forwarded so artifact manifests
+        # written by save_adapters / _save_adapters carry real lineage
+        # (closes TODO #16).
         trainer = Trainer(
+            job_id=job_id,
             data_manager=data_manager,
             output_dir=output_dir,
             config=config,

--- a/ml_engine/jobs/subprocess_runner.py
+++ b/ml_engine/jobs/subprocess_runner.py
@@ -406,7 +406,11 @@ def _job_entry_point(
         from ml_engine.jobs.registry import get_handler
 
         handler = get_handler(job_type)
+        # job_id is forwarded so handlers (and the Trainer they spawn) can
+        # populate CreateByInfo.job_id / BundleManifest.lineage with real
+        # lineage. Closes the gap that TODO #16 documented.
         handler.run(
+            job_id=job_id,
             job_config=job_config,
             output_dir=output_dir,
             progress_queue=progress_queue,

--- a/ml_engine/training/model_trainers/base.py
+++ b/ml_engine/training/model_trainers/base.py
@@ -56,6 +56,7 @@ class BaseModelTrainer(ABC):
 
     def __init__(
         self,
+        job_id: str,
         config: Dict[str, Any],
         device: torch.device,
         output_dir: Path,
@@ -65,11 +66,15 @@ class BaseModelTrainer(ABC):
         Initialize the base trainer.
 
         Args:
+            job_id: Lineage id forwarded by the parent Trainer (which got
+                it from the JobHandler / subprocess_runner). Recorded in
+                CreateByInfo.job_id when save_adapters() writes a manifest.
             config: Model-specific configuration
             device: Device to train on
             output_dir: Root output directory
             dataset_info: Dataset metadata (class mapping, etc.)
         """
+        self.job_id = job_id
         self.config = config
         self.device = device
         self.output_dir = output_dir / self.model_name
@@ -332,7 +337,7 @@ class BaseModelTrainer(ABC):
                 model_family=self.model_name,
                 base_model=base_model,
                 peft_files=peft_files,
-                created_by=CreateByInfo(job_id=None, timestamp=datetime.now().isoformat()),
+                created_by=CreateByInfo(job_id=self.job_id, timestamp=datetime.now().isoformat()),
                 checksums=None,
             )
             manifest_path = adapter_dir / "adapter.manifest.json"

--- a/ml_engine/training/model_trainers/grounding_dino.py
+++ b/ml_engine/training/model_trainers/grounding_dino.py
@@ -45,6 +45,7 @@ class GroundingDINOTrainer(BaseModelTrainer):
 
     def __init__(
         self,
+        job_id: str,
         config: Dict[str, Any],
         device: torch.device,
         output_dir: Path,
@@ -54,6 +55,7 @@ class GroundingDINOTrainer(BaseModelTrainer):
         Initialize the Grounding DINO trainer.
 
         Args:
+            job_id: Lineage id forwarded from the parent Trainer (TODO #16).
             config: Model configuration with keys:
                 - model.base_checkpoint: Path to pretrained weights
                 - lora: LoRA configuration (r, lora_alpha, target_modules, lora_dropout)
@@ -71,7 +73,7 @@ class GroundingDINOTrainer(BaseModelTrainer):
         self._positive_map_cache: Optional[torch.Tensor] = None
         self._positive_map_max_len: Optional[int] = None
 
-        super().__init__(config, device, output_dir, dataset_info)
+        super().__init__(job_id, config, device, output_dir, dataset_info)
 
     def _load_model(self) -> nn.Module:
         """Load Grounding DINO with LoRA adapters."""

--- a/ml_engine/training/model_trainers/sam.py
+++ b/ml_engine/training/model_trainers/sam.py
@@ -43,6 +43,7 @@ class SAMTrainer(BaseModelTrainer):
 
     def __init__(
         self,
+        job_id: str,
         config: Dict[str, Any],
         device: torch.device,
         output_dir: Path,
@@ -52,6 +53,7 @@ class SAMTrainer(BaseModelTrainer):
         Initialize the SAM trainer.
 
         Args:
+            job_id: Lineage id forwarded from the parent Trainer (TODO #16).
             config: Model configuration with keys:
                 - model.base_checkpoint: Path to pretrained weights
                 - model.model_type: Model type (vit_h, vit_l, vit_b)
@@ -64,7 +66,7 @@ class SAMTrainer(BaseModelTrainer):
             output_dir: Root output directory
             dataset_info: Dataset metadata
         """
-        super().__init__(config, device, output_dir, dataset_info)
+        super().__init__(job_id, config, device, output_dir, dataset_info)
 
     def _load_model(self) -> nn.Module:
         """Load SAM-HQ with LoRA adapters."""

--- a/ml_engine/training/trainer.py
+++ b/ml_engine/training/trainer.py
@@ -81,6 +81,7 @@ class Trainer:
 
     def __init__(
         self,
+        job_id: str,
         data_manager: DataManager,
         output_dir: str,
         config: Dict[str, Any],
@@ -92,6 +93,12 @@ class Trainer:
         Initialize the Trainer.
 
         Args:
+            job_id: ID of the job (or composed `f"{job_id}/{trial_id}"` for
+                experiment trials) that triggered this training run.
+                Recorded in artifact manifests via CreateByInfo.job_id and
+                BundleManifest.lineage so manifests can be traced back to
+                their producing job. Required (no default) — passing an
+                empty string is allowed for ad-hoc / test contexts.
             data_manager: DataManager instance with train/val/test splits
             output_dir: Output directory for checkpoints and logs
             config: Training configuration
@@ -99,6 +106,7 @@ class Trainer:
             progress_callback: Optional callback for progress reporting
             cancel_check: Optional function that returns True to cancel training
         """
+        self.job_id = job_id
         self.data_manager = data_manager
         self.output_dir = Path(output_dir)
         self.config = config
@@ -204,6 +212,7 @@ class Trainer:
             }
 
             self.trainers[model_name] = trainer_cls(
+                job_id=self.job_id,
                 config=model_config,
                 device=self.device,
                 output_dir=self.output_dir,
@@ -403,9 +412,7 @@ class Trainer:
         bundle_manifest = BundleManifest(
             bundle_type="teacher_training_output",
             artifacts=artifacts,
-            lineage={
-                "job_id": None,
-            },
+            lineage={"job_id": self.job_id},
             merged_checkpoints=None,
         )
         bundle_manifest.save(self.output_dir / "bundle.manifest.json")

--- a/tests/unit/ml_engine/test_experiment_loop_handler.py
+++ b/tests/unit/ml_engine/test_experiment_loop_handler.py
@@ -106,6 +106,7 @@ def _run_handler(
 
             handler = ExperimentLoopHandler()
             handler.run(
+                job_id="test-job-experiment-loop",
                 job_config=job_config,
                 output_dir=output_dir,
                 progress_queue=ctx.Queue(),
@@ -243,6 +244,7 @@ class TestBudgetConstruction:
                 instance.run.side_effect = capture
                 MockLoop.return_value = instance
                 ExperimentLoopHandler().run(
+                    job_id="test-job-budget-capture",
                     job_config=job_config,
                     output_dir=output_dir,
                     progress_queue=ctx.Queue(),
@@ -293,6 +295,7 @@ class TestValidation:
             ):
                 with pytest.raises(ValueError, match=match):
                     ExperimentLoopHandler().run(
+                        job_id="test-job-validation",
                         job_config=job_config,
                         output_dir=output_dir,
                         progress_queue=ctx.Queue(),

--- a/tests/unit/ml_engine/test_lineage.py
+++ b/tests/unit/ml_engine/test_lineage.py
@@ -1,0 +1,192 @@
+"""
+Lineage plumbing tests for TODO #16.
+
+These tests pin down the contract that artifact manifests carry a real
+job_id end-to-end:
+
+- Every JobHandler subclass accepts `job_id` in its run() signature
+  (catches future drift if someone adds a new handler that forgets the
+  param — the abstract base would let them, since Python doesn't enforce
+  parameter names on overrides).
+- Trainer and BaseModelTrainer accept `job_id` and propagate it.
+- For experiment trials, the trial subprocess receives a composed
+  `f"{job_id}/{trial_id}"` so manifests can be traced to both.
+- The artifact dataclasses (CreateByInfo, BundleManifest) require a real
+  job_id (no longer Optional after TODO #16 plumbing landed).
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Dict, get_type_hints
+
+import pytest
+
+from ml_engine.artifacts.schemas import (
+    AdapterManifest,
+    BaseModelRef,
+    BundleManifest,
+    CreateByInfo,
+)
+
+
+class TestHandlerSignatures:
+    """Catches future handlers that drift from the abstract JobHandler.run signature."""
+
+    @pytest.mark.parametrize(
+        "module_path, class_name",
+        [
+            ("ml_engine.jobs.handlers.base", "JobHandler"),
+            ("ml_engine.jobs.handlers.teacher", "TeacherTrainingHandler"),
+            ("ml_engine.jobs.handlers.auto_label", "AutoLabelHandler"),
+            ("ml_engine.jobs.handlers.distillation", "StudentDistillationHandler"),
+            ("ml_engine.jobs.handlers.experiment_loop", "ExperimentLoopHandler"),
+        ],
+    )
+    def test_handler_run_accepts_job_id(self, module_path: str, class_name: str) -> None:
+        import importlib
+
+        mod = importlib.import_module(module_path)
+        cls = getattr(mod, class_name)
+        sig = inspect.signature(cls.run)
+        assert "job_id" in sig.parameters, (
+            f"{class_name}.run() is missing the `job_id` parameter — "
+            f"the abstract JobHandler.run requires it as of TODO #16. "
+            f"Without it, artifact manifests written by this handler would "
+            f"have no lineage back to the parent job."
+        )
+        # Also lock the type to str (not Optional) so Trainer doesn't
+        # accept None and silently drop lineage.
+        hints = get_type_hints(cls.run)
+        assert hints.get("job_id") is str, (
+            f"{class_name}.run() job_id must be typed `str` (non-Optional) — got {hints.get('job_id')!r}."
+        )
+
+
+class TestTrainerSignatures:
+    """Trainer + BaseModelTrainer must accept and store job_id."""
+
+    def test_trainer_init_accepts_job_id(self) -> None:
+        from ml_engine.training.trainer import Trainer
+
+        sig = inspect.signature(Trainer.__init__)
+        assert "job_id" in sig.parameters
+        hints = get_type_hints(Trainer.__init__)
+        assert hints.get("job_id") is str
+
+    def test_base_model_trainer_init_accepts_job_id(self) -> None:
+        from ml_engine.training.model_trainers.base import BaseModelTrainer
+
+        sig = inspect.signature(BaseModelTrainer.__init__)
+        assert "job_id" in sig.parameters
+        hints = get_type_hints(BaseModelTrainer.__init__)
+        assert hints.get("job_id") is str
+
+    @pytest.mark.parametrize(
+        "module_path, class_name",
+        [
+            ("ml_engine.training.model_trainers.grounding_dino", "GroundingDINOTrainer"),
+            ("ml_engine.training.model_trainers.sam", "SAMTrainer"),
+        ],
+    )
+    def test_concrete_trainers_accept_job_id(self, module_path: str, class_name: str) -> None:
+        """Subclasses must thread job_id through to super().__init__."""
+        import importlib
+
+        mod = importlib.import_module(module_path)
+        cls = getattr(mod, class_name)
+        sig = inspect.signature(cls.__init__)
+        assert "job_id" in sig.parameters, (
+            f"{class_name}.__init__() is missing `job_id` — BaseModelTrainer requires it as of TODO #16."
+        )
+
+
+class TestTrialRunnerComposition:
+    """ExperimentLoop / TrialRunner compose `f'{job_id}/{trial_id}'` for trial manifests."""
+
+    def test_trial_runner_run_accepts_job_id(self) -> None:
+        from ml_engine.experiment.trial_runner import TrialRunner
+
+        sig = inspect.signature(TrialRunner.run)
+        assert "job_id" in sig.parameters
+
+    def test_experiment_loop_run_accepts_job_id(self) -> None:
+        from ml_engine.experiment.loop import ExperimentLoop
+
+        sig = inspect.signature(ExperimentLoop.run)
+        assert "job_id" in sig.parameters
+
+    def test_trial_subprocess_first_arg_is_composed_job_id(self) -> None:
+        """
+        _trial_subprocess takes `composed_job_id` as the first positional arg
+        (so it can be passed to Trainer(job_id=...) inside the spawn'd process).
+        Pinning the parameter name + position prevents accidental reorders that
+        would put data_manager into the job_id slot.
+        """
+        from ml_engine.experiment.trial_runner import _trial_subprocess
+
+        params = list(inspect.signature(_trial_subprocess).parameters)
+        assert params[0] == "composed_job_id", (
+            f"Expected first param of _trial_subprocess to be "
+            f"'composed_job_id', got {params[0]!r}. The composed value "
+            f"f'{{job_id}}/{{trial_id}}' must be the first positional arg "
+            f"so the spawn-context Process's args tuple stays ordered."
+        )
+
+
+class TestSchemaContract:
+    """The artifact dataclasses now require a real job_id (TODO #16 reverted Optional)."""
+
+    def test_create_by_info_requires_job_id(self) -> None:
+        # str — not Optional[str]. Constructing with a real value works.
+        info = CreateByInfo(job_id="job-abc", timestamp="2026-04-26T12:00:00Z")
+        assert info.job_id == "job-abc"
+
+        # Type contract: job_id field is typed `str` exactly.
+        hints = get_type_hints(CreateByInfo)
+        assert hints["job_id"] is str
+
+    def test_bundle_manifest_lineage_requires_str_values(self) -> None:
+        manifest = BundleManifest(
+            bundle_type="teacher_training_output",
+            artifacts={"sam": "sam/lora_adapters/adapter.manifest.json"},
+            lineage={"job_id": "job-abc"},
+        )
+        assert manifest.lineage["job_id"] == "job-abc"
+
+        # Type contract: lineage is Dict[str, str], no Optional anywhere.
+        # (typing.Dict[str, str], not the lowercase builtin form — pinned
+        # to whichever the schema uses today so a future migration is
+        # noticed and the assertion updated explicitly.)
+        hints = get_type_hints(BundleManifest)
+        assert hints["lineage"] == Dict[str, str]
+
+    def test_full_manifest_save_load_roundtrip_preserves_job_id(self, tmp_path) -> None:
+        """End-to-end: writing and reading back a manifest preserves job_id verbatim."""
+        manifest = AdapterManifest(
+            model_family="grounding_dino",
+            base_model=BaseModelRef(checkpoint_path="data/models/dino.pth"),
+            peft_files={"config": "adapter_config.json", "weights": "adapter_model.safetensors"},
+            created_by=CreateByInfo(
+                job_id="job-abc/trial_001",
+                timestamp="2026-04-26T12:00:00Z",
+            ),
+        )
+        path = tmp_path / "adapter.manifest.json"
+        manifest.save(path)
+
+        loaded = AdapterManifest.load(path)
+        assert loaded.created_by.job_id == "job-abc/trial_001"
+
+    def test_composed_trial_id_format_is_recoverable(self) -> None:
+        """
+        Composed format `f'{job_id}/{trial_id}'` should be deterministic so
+        future tools can split it. We're not adding a parser here (one-way
+        composition is fine for now), but pin the format so it doesn't drift.
+        """
+        composed = "job-abc/trial_003"
+        # Round-trip via str.split('/', 1) — single split, in case job_id
+        # ever contains a '/' (unlikely; UUIDs don't).
+        parent, trial = composed.split("/", 1)
+        assert parent == "job-abc"
+        assert trial == "trial_003"


### PR DESCRIPTION
Reverts the Optional[str] widening in CreateByInfo.job_id and BundleManifest.lineage that Step 2.4.3 of TODO 6 had to apply as a marker for this gap. The value is known at job submission time but was being dropped at the subprocess boundary in subprocess_runner.

PLUMBING (top-down, per the TODO 16 entry):

1. ml_engine/jobs/handlers/base.py — JobHandler.run() abstract signature adds `job_id: str` as the first positional arg.

2. ml_engine/jobs/subprocess_runner.py:409 — _job_entry_point now passes `job_id=job_id` to handler.run() (the variable already existed at line 333, just wasn't forwarded).

3. All 4 handler subclasses accept and forward job_id:
   - teacher.py — passes to Trainer(job_id=job_id, ...)
   - auto_label.py — accepts (no Trainer downstream; threaded for Protocol/abstract compliance)
   - distillation.py — accepts (StudentDistillationHandler doesn't write CreateByInfo manifests today; ready when it does)
   - experiment_loop.py — passes to ExperimentLoop.run(job_id=...)

4. ml_engine/experiment/loop.py — ExperimentLoop.run() takes job_id and forwards to TrialRunner.run(job_id=...).

5. ml_engine/experiment/trial_runner.py — TrialRunner.run() composes `composed_job_id = f"{job_id}/{trial_id}"` (e.g. "job-abc/trial_003") per option (c) of the TODO 16 design. _trial_subprocess takes composed_job_id as the first positional arg and passes to Trainer(job_id=composed_job_id, ...).

6. ml_engine/training/trainer.py — Trainer.__init__ adds `job_id: str`, stores `self.job_id`, propagates to per-model trainers in _init_trainers, and uses it in BundleManifest's `lineage={"job_id": self.job_id}` (was `{"job_id": None}`).

7. ml_engine/training/model_trainers/base.py — BaseModelTrainer.__init__ adds `job_id: str` (first positional arg), uses it in CreateByInfo(job_id=self.job_id, ...) (was `job_id=None`).

8. ml_engine/training/model_trainers/{grounding_dino,sam}.py — both subclasses accept job_id and thread to super().__init__.

SCHEMA REVERTS (ml_engine/artifacts/schemas.py):

- CreateByInfo.job_id: Optional[str] → str (with docstring documenting the f"{job_id}/{trial_id}" trial composition)
- BundleManifest.lineage: Dict[str, Optional[str]] → Dict[str, str]
- Removed TODO 16 marker comment blocks (now stale)

TESTS:

- tests/unit/ml_engine/test_experiment_loop_handler.py — 3 ExperimentLoopHandler.run() callsites now pass `job_id="test-job-..."` fixture strings.
- tests/unit/ml_engine/test_lineage.py — NEW. 16 tests pinning the contract: every JobHandler subclass + Trainer + BaseModelTrainer + GroundingDINOTrainer + SAMTrainer + TrialRunner + ExperimentLoop accept job_id; _trial_subprocess's first positional arg is composed_job_id; CreateByInfo + BundleManifest.lineage are non-Optional; AdapterManifest save/load roundtrip preserves job_id verbatim (including the composed parent/trial form).

VERIFIED:
- mypy core ml_engine api augmentation --follow-imports=silent: clean (0 errors across 119 source files).
- pytest tests/unit/ml_engine/test_lineage.py: 16 passed.
- pytest tests/unit/ml_engine/{artifacts,distillation,data}/: 295 passed, 4 xfailed (pre-existing distillation xfails, unrelated).

Manifests written by training jobs from now on will carry real lineage:
- For standalone teacher_training jobs: created_by.job_id = the parent job id from JobManager.submit_job
- For experiment trials: created_by.job_id = parent_experiment_job_id/trial_NNN

This unlocks: post-hoc debugging ("which job made this bad model?"), audit/compliance, automated cleanup of artifacts from cancelled jobs, and future eval-tracking that correlates performance with training config.