### PR TITLE
fix(augmentation): _keep_higher_p raises ValueError on missing p key

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -251,52 +251,6 @@ and the audit, but each wants a callsite enumeration before shipping.
 
 ---
 
-### 19. `_keep_higher_p` crashes with KeyError when a transform's params lack `p`
-
-**What:** `CharacteristicTranslator._keep_higher_p` at
-`augmentation/characteristic_translator.py:1109-1110` does
-`existing["p"]` and `new["p"]` directly. If a future rule defines a
-transform without a `p` parameter, the dedup path crashes with a bare
-`KeyError: 'p'` — confusing if the rule author doesn't know dedup is
-the consumer.
-
-**Test surface:** 1 xfail in `tests/unit/augmentation/test_characteristic_translator.py`
-(`TestKeepHigherPMissingProbabilityKey::test_missing_p_should_raise_clear_error`)
-documents the gap. When the fix lands, flip the `@pytest.mark.xfail`
-decorator off.
-
-**Fix options (1-3 lines):**
-
-- **Lenient:** treat missing `p` as priority 0 — `existing.get("p", 0.0)`
-  / `new.get("p", 0.0)`. Existing rule (with `p`) wins by default.
-- **Strict:** add the `p` check to `AugmentationRule.__post_init__` so
-  malformed rules fail loudly at module-import time, not at translate-
-  call time. The test in
-  `TestCharacteristicSchemaIntegrity::test_every_transform_has_probability`
-  enforces this for the 5 spot-checked characteristics; promoting it
-  to `__post_init__` covers all 21 rules.
-- **Both:** validate at construction (strict) AND fall back to 0.0 in
-  the dedup path (defense-in-depth for future runtime-mutated rules).
-
-**Why deferred:** Cosmetic / defensive. No live rule violates the
-constraint today (the schema-integrity tests pass for all 5 spot-
-checked characteristics; spot-checking the remaining 16 is mechanical).
-Worth filing so a fix lands the next time someone touches the rules.
-
-**Pros:** Clearer error for the rule author; defense-in-depth.
-
-**Cons:** None of consequence. The lenient fallback could mask a
-typo'd `p` key (`prob` instead of `p`) by treating it as priority 0.
-
-**Test surface:** No new tests needed — `test_characteristic_translator.py`
-already has the xfail.
-
-**Context:** Surfaced 2026-04-27 during item #12.3 (P2 unit test
-roster — `test_characteristic_translator.py`).
-
-**Depends on / blocked by:** None.
-
----
 
 ### 20. Refine Coordinator crash classification (failed_retrying for transient errors)
 
@@ -391,3 +345,4 @@ Item numbers are stable so commit messages and PR descriptions referencing
 - **#17** Restore `text_threshold` token-level filtering in `GroundingDINODetector` ✅ → [docs/decisions/17-text-threshold-filtering.md](docs/decisions/17-text-threshold-filtering.md) — `logits_to_class_scores` now zeros sub-threshold tokens before per-class mean; `detect()` passes the param through instead of discarding it; 32 adversarial tests (boundary, mutation, class-flip, dilution, NMS, monotone sweep). Shipped 2026-04-28.
 - **#16** Plumb `job_id` through training pipeline so artifact manifests carry real lineage ✅ → [docs/decisions/16-job-id-lineage-plumbing.md](docs/decisions/16-job-id-lineage-plumbing.md) — first follow-up surfaced by #6. Trial subprocesses use composed `f"{job_id}/{trial_id}"` form. Shipped 2026-04-27 (PR #41).
 - **#14** `tests/test_sam_lora.py` audit — 13 stale failures + CI scope gap ✅ — All 13 failures were stale tests. Moved to `tests/unit/ml_engine/test_sam_lora.py` so CI picks them up. Fixed 3 real bugs: `upscale_masks()` crashes on 5D multimask tensors (5D reshape path added); `SegmentationLoss` ignored `iou_predictions` (IoU quality MSE regression added); `box_prompts=[N=0]` now raises clear `ValueError` at call site. Pre-landing: added explicit `[B,N]` shape guard + clear error on `iou_predictions`, `iou_quality` key in default weights dict, rank guard on `upscale_masks`. 24 tests. Shipped 2026-04-28.
+- **#19** `_keep_higher_p` KeyError on missing `p` key ✅ — Added guard at `characteristic_translator.py:1109` that raises `ValueError` with a clear message when either params dict is missing `p`. xfail test promoted to passing regression guard (93 pass, 0 xfail). Shipped 2026-04-28.

--- a/augmentation/characteristic_translator.py
+++ b/augmentation/characteristic_translator.py
@@ -1106,6 +1106,9 @@ class CharacteristicTranslator:
         Returns:
             Parameter dict with higher probability
         """
+        if "p" not in existing or "p" not in new:
+            missing = "existing" if "p" not in existing else "new"
+            raise ValueError(f"_keep_higher_p: {missing} params dict is missing the 'p' probability key")
         existing_p = existing["p"]
         new_p = new["p"]
 

--- a/tests/unit/augmentation/test_characteristic_translator.py
+++ b/tests/unit/augmentation/test_characteristic_translator.py
@@ -358,14 +358,6 @@ class TestKeepHigherPMissingProbabilityKey:
     Documenting + flagging as a gap so adding new rules without `p`
     fails loudly here, not deep in dedup."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="characteristic_translator.py:1109-1110 — _keep_higher_p "
-        "does `existing['p']` and `new['p']` directly. Missing `p` raises "
-        "KeyError instead of a clear message. Either guard with `.get('p', "
-        "0.0)` (treats missing as lowest priority) or raise a clearer "
-        "AugmentationRule validation error in __post_init__.",
-    )
     def test_missing_p_should_raise_clear_error(self, translator):
         existing = {"alpha": RangeParameter.scalar(0.5)}  # no "p"
         new = {"p": RangeParameter.scalar(0.5)}


### PR DESCRIPTION
## fix(augmentation): _keep_higher_p raises ValueError on missing `p` key (TODO 19)

Defensive 3-line guard in `CharacteristicTranslator._keep_higher_p`. No behavior
change for any existing rule — all live rules include `p`. Closes the last open
xfail from the P2 test roster (TODO 12).

---

## What was wrong

`_keep_higher_p` is the dedup tiebreaker: when two characteristics both emit the
same transform type, it keeps whichever has the higher probability. It accessed
`existing["p"]` and `new["p"]` directly. If a future rule defined a transform
without a `p` key, the merge path would crash with a bare `KeyError: 'p'` — no
indication that `_keep_higher_p` was the consumer, no indication which dict was
malformed.

## Fix

```python
if "p" not in existing or "p" not in new:
    missing = "existing" if "p" not in existing else "new"
    raise ValueError(
        f"_keep_higher_p: {missing} params dict is missing the 'p' probability key"
    )
