### PR TITLE
Fix/keep higher p followup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] — 2026-04-28
+
+### Fixed
+
+- **`_keep_higher_p` error message when both dicts missing `p`** — previously only reported one of the two missing dicts; now reports all missing dicts in a single `ValueError`. Symmetric test cases added for `new`-missing and both-missing paths.
+
 ## [0.1.2] — 2026-04-28
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -326,6 +326,38 @@ re-launched Coordinator can actually pick up the run.
 
 ---
 
+### 25. `CharacteristicSchemaIntegrity` tests cover only 5 of 9 characteristics
+
+**What:** `TestCharacteristicSchemaIntegrity::test_every_transform_has_probability` spot-checks `changes_shape`, `low_contrast`, `reflective_surface`, `partially_hidden`, `moves_or_vibrates`. Four characteristics are unchecked: `changes_size`, `semi_transparent`, `similar_to_background`, `multiple_objects`. A missing `p` key in any of their transforms would evade the test and crash `_keep_higher_p` at runtime.
+
+**Also:** `semi_transparent` low-intensity `RandomFog` uses key `alpha_corf` — likely a typo for `alpha_coef` (used consistently elsewhere at lines 314 and 330). The schema test doesn't catch data typos, only missing `p`.
+
+**Fix (2 parts):**
+- Extend the parametrize list in `test_every_transform_has_probability` to include all 9 characteristics.
+- Verify `semi_transparent`'s `alpha_corf` key is intentional or correct it.
+
+**Why deferred:** Same pattern as TODO #19. No live overlap collision today, but adding a new rule for any of the 4 unchecked characteristics without `p` would crash silently.
+
+**Context:** Surfaced 2026-04-28 during `/ship` adversarial review of PR #50.
+
+**Depends on / blocked by:** None. Mechanical extension.
+
+---
+
+### 26. Environment rules have no schema integrity tests
+
+**What:** `CHARACTERISTIC_RULES` has schema tests in `TestCharacteristicSchemaIntegrity`, but `ENVIRONMENT_RULES` (12 environment rules: `variable_lighting`, `fixed_camera`, etc.) has no equivalent. `_keep_higher_p` is called in both the characteristic dedup loop (line 1183) and the environment dedup loop (line 1207). An environment rule missing `p` in any transform would crash `_keep_higher_p` at runtime.
+
+**Fix:** Add `TestEnvironmentSchemaIntegrity` class mirroring `TestCharacteristicSchemaIntegrity` — parametrize over all environment rule keys, assert every transform at every intensity has a `p` key.
+
+**Why deferred:** No live environment rule violates the constraint today. Defensive coverage.
+
+**Context:** Surfaced 2026-04-28 during `/ship` adversarial review of PR #50.
+
+**Depends on / blocked by:** None. ~20 lines of test.
+
+---
+
 ## Completed
 
 One-line stubs for items that have shipped. Long-form context (what shipped,

--- a/augmentation/characteristic_translator.py
+++ b/augmentation/characteristic_translator.py
@@ -1106,9 +1106,11 @@ class CharacteristicTranslator:
         Returns:
             Parameter dict with higher probability
         """
-        if "p" not in existing or "p" not in new:
-            missing = "existing" if "p" not in existing else "new"
-            raise ValueError(f"_keep_higher_p: {missing} params dict is missing the 'p' probability key")
+        missing = [name for name, d in (("existing", existing), ("new", new)) if "p" not in d]
+        if missing:
+            raise ValueError(
+                f"_keep_higher_p: {' and '.join(missing)} params dict(s) missing the 'p' probability key"
+            )
         existing_p = existing["p"]
         new_p = new["p"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grounded-segment-anything"
-version = "0.1.2"
+version = "0.1.3"
 description = "ML platform: Grounding DINO + SAM for auto-labeling, training, and inference"
 requires-python = ">=3.10,<3.11"
 dependencies = [

--- a/tests/unit/augmentation/test_characteristic_translator.py
+++ b/tests/unit/augmentation/test_characteristic_translator.py
@@ -358,9 +358,21 @@ class TestKeepHigherPMissingProbabilityKey:
     Documenting + flagging as a gap so adding new rules without `p`
     fails loudly here, not deep in dedup."""
 
-    def test_missing_p_should_raise_clear_error(self, translator):
+    def test_missing_p_existing_raises_clear_error(self, translator):
         existing = {"alpha": RangeParameter.scalar(0.5)}  # no "p"
         new = {"p": RangeParameter.scalar(0.5)}
+        with pytest.raises(ValueError, match="probability"):
+            translator._keep_higher_p(existing, new)
+
+    def test_missing_p_new_raises_clear_error(self, translator):
+        existing = {"p": RangeParameter.scalar(0.5)}
+        new = {"alpha": RangeParameter.scalar(0.5)}  # no "p"
+        with pytest.raises(ValueError, match="probability"):
+            translator._keep_higher_p(existing, new)
+
+    def test_missing_p_both_raises_clear_error(self, translator):
+        existing = {"alpha": RangeParameter.scalar(0.5)}  # no "p"
+        new = {"alpha": RangeParameter.scalar(0.3)}  # no "p"
         with pytest.raises(ValueError, match="probability"):
             translator._keep_higher_p(existing, new)
 


### PR DESCRIPTION
## fix(augmentation): _keep_higher_p error message + symmetric tests (v0.1.3)

Followup to PR #50. Retroactive adversarial review found two issues
in the guard added in `c189a5b` — fixed here before the pattern spreads.

---

## What was wrong

### 1. Error message lied when both dicts were missing `p`

The original guard:

```python
missing = "existing" if "p" not in existing else "new"
raise ValueError(f"_keep_higher_p: {missing} params dict is missing the 'p' probability key")
```
when both `existing` and `new` lacked `"p"`, the message reported only `"existing"`. An operator would fix that dict, redeploy, and hit the error again for `"new"`.

**Fix**: Collect all missing dict names first, then raise once:

```python
missing = [name for name, d in (("existing", existing), ("new", new)) if "p" not in d]
if missing:
    raise ValueError(
        f"_keep_higher_p: {' and '.join(missing)} params dict(s) missing the 'p' probability key"
    )
```

### 2. The `"new"` branch was untested
`TestKeepHigherPMissingProbabilityKey` only tested `existing` missing `p`. 
The `"new"` path in the ternary was dead code from the test suite's perspective, so a regression to the variable assignment would not be caught.
**Fix**: Two new tests added:
- `test_missing_p_new_raises_clear_error`: `new` missing `p`, `existing` has it
- `test_missing_p_both_raises_clear_error`: both dict missing `p`


