### PR TITLE
52 pending contract approval no endpoint to advance out of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] — 2026-04-28
+
+### Fixed
+
+- **`pending_contract_approval` gate endpoint** — `POST /api/agent/gate/{run_id}/approve` now handles both human gate states. Previously the endpoint only accepted runs in `pending_approval`; runs paused at `pending_contract_approval` (the start-of-pipeline contract review) had no way to advance and would stall permanently. Approve transitions to `auto_labeling` (event: `contract_approved`); reject transitions to `cancelled` (event: `contract_rejected`).
+- **`pending_approval` reject state bug** — rejecting at the end-of-pipeline gate previously attempted to transition to `escalated`, which is not a valid target from `pending_approval` per the state machine. Fixed to `cancelled` (consistent with human-initiated cancellation). Discovered and caught by the new gate tests.
+
+### Tests
+
+- `TestHumanGate` added to `tests/unit/api/test_agent_coordinator.py` (13 tests): covers both gate states (approve/reject), invalid action (400), unknown run (404), non-gate states (409), event type assertions for `contract_approved` / `contract_rejected`, and `ValueError` propagation from `sm.transition()` → 400.
+
 ## [0.1.3] — 2026-04-28
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -267,18 +267,9 @@ re-launched Coordinator can actually pick up the run.
 
 ---
 
-### 21. `pending_contract_approval` — no endpoint to advance out of it (blocker)
+### ~~21. `pending_contract_approval` — no endpoint to advance out of it (blocker)~~
 
-**What:** `TRANSITIONS["pending_contract_approval"]` allows `["auto_labeling", "teacher_training", "cancelled", "failed_unrecoverable"]`, but no API endpoint drives any of those transitions. `/gate/{run_id}/{action}` only handles `pending_approval`. `/approve` only handles `created → planning`. A run that reaches `pending_contract_approval` — whether first time or after a restart — is permanently stuck.
-
-**Why:** `pending_contract_approval` is listed in `HUMAN_GATE_STAGES` in `coordinator.py`, so the Coordinator ignores all stream events in this state. The design assumes an external actor (human or endpoint) drives the transition, but that actor doesn't exist yet.
-
-**Decision needed:** Two options with different UX implications:
-
-- **Option A — Human-gated pause.** Keep `pending_contract_approval` as a deliberate review point. Add `POST /api/agent/contract/{run_id}/accept` (→ `auto_labeling` or `teacher_training`) and `POST /api/agent/contract/{run_id}/reject` (→ `cancelled`). The frontend shows the LLM-refined contract for approval before the pipeline starts. This mirrors the `pending_approval` gate at the end.
-- **Option B — Auto-advance.** Remove `pending_contract_approval` from `HUMAN_GATE_STAGES`. The Coordinator calls `advance_gate` twice in the `contract_approved` handler: first `planning → pending_contract_approval`, then immediately `pending_contract_approval → auto_labeling`. Effectively a no-op pause state; keep the state in the machine for observability but don't block on human input. Simpler, but loses the contract review UX.
-
-**Context:** State machine at [ml_engine/agent/state_machine.py:67-91](ml_engine/agent/state_machine.py#L67-L91). `HUMAN_GATE_STAGES` at [ml_engine/agent/coordinator.py:51](ml_engine/agent/coordinator.py#L51). Gate endpoint at [api/routes/agent.py:362-414](api/routes/agent.py#L362-L414).
+**Completed:** v0.1.4 (2026-04-28) — Extended `POST /api/agent/gate/{run_id}/{action}` to handle `pending_contract_approval`. Chose Option A (human-gated pause): approve → `auto_labeling` (event: `contract_approved`), reject → `cancelled`. Also fixed pre-existing bug where `pending_approval` reject incorrectly targeted `escalated` (not a valid SM transition). 13 unit tests in `TestHumanGate`. GitHub issue #52.
 
 **Depends on / blocked by:** None. Self-contained. Should be resolved before any end-to-end integration testing since the happy path goes through this state.
 

--- a/api/routes/agent.py
+++ b/api/routes/agent.py
@@ -369,12 +369,17 @@ async def get_status(run_id: str):
 @router.post("/gate/{run_id}/{action}")
 async def human_gate(run_id: str, action: str, body: GateActionRequest):
     """
-    Human gate decision for pending_approval state.
+    Human gate decision for any gate state.
 
     action: "approve" | "reject"
 
-    approve -> transitions to "done"
-    reject  -> transitions to "escalated" with reason
+    pending_approval (end-of-pipeline gate):
+        approve -> "done"       (event: gate_approved)
+        reject  -> "cancelled"  (event: gate_rejected)
+
+    pending_contract_approval (start-of-pipeline gate):
+        approve -> "auto_labeling"  (event: contract_approved)
+        reject  -> "cancelled"      (event: contract_rejected)
     """
     from ml_engine.agent.loop import apublish_event
     from ml_engine.agent.state_machine import StateMachine
@@ -390,13 +395,21 @@ async def human_gate(run_id: str, action: str, body: GateActionRequest):
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
 
-    if current != "pending_approval":
+    if current == "pending_approval":
+        target_state = "done" if action == "approve" else "cancelled"
+        event_type = "gate_approved" if action == "approve" else "gate_rejected"
+    elif current == "pending_contract_approval":
+        target_state = "auto_labeling" if action == "approve" else "cancelled"
+        event_type = "contract_approved" if action == "approve" else "contract_rejected"
+    else:
         raise HTTPException(
             status_code=409,
-            detail=f"Run is in state {current!r}, not pending_approval",
+            detail=(
+                f"Run is in state {current!r}, not a gate state "
+                "(pending_approval or pending_contract_approval)"
+            ),
         )
 
-    target_state = "done" if action == "approve" else "escalated"
     try:
         await sm.transition(target_state)
     except ValueError as e:
@@ -406,7 +419,7 @@ async def human_gate(run_id: str, action: str, body: GateActionRequest):
         r,
         run_id,
         {
-            "type": "gate_approved" if action == "approve" else "gate_rejected",
+            "type": event_type,
             "run_id": run_id,
             "action": action,
             "reason": body.reason,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grounded-segment-anything"
-version = "0.1.3"
+version = "0.1.4"
 description = "ML platform: Grounding DINO + SAM for auto-labeling, training, and inference"
 requires-python = ">=3.10,<3.11"
 dependencies = [

--- a/tests/unit/api/test_agent_coordinator.py
+++ b/tests/unit/api/test_agent_coordinator.py
@@ -569,3 +569,242 @@ class TestScanNonTerminalRunIds:
 
         result = await StateMachine.scan_non_terminal_run_ids(fake_redis)
         assert run_id not in result
+
+
+# ---------------------------------------------------------------------------
+# Human gate endpoint (#52)
+# ---------------------------------------------------------------------------
+
+
+def _gate_patches(fake_redis):
+    """Minimal patches for human_gate: Redis + suppress apublish_event side-effects."""
+    return (
+        patch("api.routes.agent._get_async_redis", return_value=fake_redis),
+        patch("ml_engine.agent.loop.apublish_event", return_value=None),
+    )
+
+
+class TestHumanGate:
+    # --- input validation ---
+
+    @pytest.mark.asyncio
+    async def test_invalid_action_returns_400(self, fake_redis):
+        run_id = "gate-bad-action-0001"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await fake_redis.hset(sm._key, "state", "pending_approval")
+
+        with _gate_patches(fake_redis)[0], _gate_patches(fake_redis)[1]:
+            from fastapi.testclient import TestClient
+
+            from api.app import app
+
+            with TestClient(app) as client:
+                resp = client.post(f"/api/agent/gate/{run_id}/kick", json={"reason": ""})
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_unknown_run_returns_404(self, fake_redis):
+        with _gate_patches(fake_redis)[0], _gate_patches(fake_redis)[1]:
+            from fastapi.testclient import TestClient
+
+            from api.app import app
+
+            with TestClient(app) as client:
+                resp = client.post("/api/agent/gate/no-such-run/approve", json={"reason": ""})
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("non_gate_state", ["planning", "auto_labeling", "teacher_training", "done"])
+    @pytest.mark.asyncio
+    async def test_non_gate_state_returns_409(self, fake_redis, non_gate_state):
+        run_id = f"gate-wrong-state-{non_gate_state}"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await fake_redis.hset(sm._key, "state", non_gate_state)
+
+        with _gate_patches(fake_redis)[0], _gate_patches(fake_redis)[1]:
+            from fastapi.testclient import TestClient
+
+            from api.app import app
+
+            with TestClient(app) as client:
+                resp = client.post(f"/api/agent/gate/{run_id}/approve", json={"reason": ""})
+        assert resp.status_code == 409
+
+    # --- pending_approval gate ---
+
+    @pytest.mark.asyncio
+    async def test_pending_approval_approve_transitions_to_done(self, fake_redis):
+        run_id = "gate-pa-approve-0001"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await fake_redis.hset(sm._key, "state", "pending_approval")
+
+        with _gate_patches(fake_redis)[0], _gate_patches(fake_redis)[1]:
+            from fastapi.testclient import TestClient
+
+            from api.app import app
+
+            with TestClient(app) as client:
+                resp = client.post(f"/api/agent/gate/{run_id}/approve", json={"reason": "LGTM"})
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["new_state"] == "done"
+        assert await sm.current_state() == "done"
+
+    @pytest.mark.asyncio
+    async def test_pending_approval_reject_transitions_to_cancelled(self, fake_redis):
+        run_id = "gate-pa-reject-0001"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await fake_redis.hset(sm._key, "state", "pending_approval")
+
+        with _gate_patches(fake_redis)[0], _gate_patches(fake_redis)[1]:
+            from fastapi.testclient import TestClient
+
+            from api.app import app
+
+            with TestClient(app) as client:
+                resp = client.post(f"/api/agent/gate/{run_id}/reject", json={"reason": "results look off"})
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["new_state"] == "cancelled"
+        assert await sm.current_state() == "cancelled"
+
+    # --- pending_contract_approval gate ---
+
+    @pytest.mark.asyncio
+    async def test_pending_contract_approval_approve_transitions_to_auto_labeling(self, fake_redis):
+        run_id = "gate-pca-approve-0001"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await fake_redis.hset(sm._key, "state", "pending_contract_approval")
+
+        with _gate_patches(fake_redis)[0], _gate_patches(fake_redis)[1]:
+            from fastapi.testclient import TestClient
+
+            from api.app import app
+
+            with TestClient(app) as client:
+                resp = client.post(
+                    f"/api/agent/gate/{run_id}/approve", json={"reason": "contract looks good"}
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["new_state"] == "auto_labeling"
+        assert await sm.current_state() == "auto_labeling"
+
+    @pytest.mark.asyncio
+    async def test_pending_contract_approval_reject_transitions_to_cancelled(self, fake_redis):
+        run_id = "gate-pca-reject-0001"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await fake_redis.hset(sm._key, "state", "pending_contract_approval")
+
+        with _gate_patches(fake_redis)[0], _gate_patches(fake_redis)[1]:
+            from fastapi.testclient import TestClient
+
+            from api.app import app
+
+            with TestClient(app) as client:
+                resp = client.post(f"/api/agent/gate/{run_id}/reject", json={"reason": "budget too high"})
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["new_state"] == "cancelled"
+        assert await sm.current_state() == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_contract_approval_publishes_contract_approved_event(self, fake_redis):
+        """Approve on pending_contract_approval must publish 'contract_approved' (not 'contract_accepted')."""
+        run_id = "gate-pca-event-0001"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await fake_redis.hset(sm._key, "state", "pending_contract_approval")
+
+        published: list = []
+
+        async def _capture_event(r, rid, event):
+            published.append(event)
+
+        with (
+            _gate_patches(fake_redis)[0],
+            patch("ml_engine.agent.loop.apublish_event", side_effect=_capture_event),
+        ):
+            from fastapi.testclient import TestClient
+
+            from api.app import app
+
+            with TestClient(app) as client:
+                client.post(f"/api/agent/gate/{run_id}/approve", json={"reason": ""})
+
+        assert len(published) == 1
+        assert published[0]["type"] == "contract_approved"
+
+    @pytest.mark.asyncio
+    async def test_contract_rejection_publishes_contract_rejected_event(self, fake_redis):
+        """Reject on pending_contract_approval must publish 'contract_rejected'."""
+        run_id = "gate-pca-reject-event-0001"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await fake_redis.hset(sm._key, "state", "pending_contract_approval")
+
+        published: list = []
+
+        async def _capture_event(r, rid, event):
+            published.append(event)
+
+        with (
+            _gate_patches(fake_redis)[0],
+            patch("ml_engine.agent.loop.apublish_event", side_effect=_capture_event),
+        ):
+            from fastapi.testclient import TestClient
+
+            from api.app import app
+
+            with TestClient(app) as client:
+                client.post(f"/api/agent/gate/{run_id}/reject", json={"reason": "too expensive"})
+
+        assert len(published) == 1
+        assert published[0]["type"] == "contract_rejected"
+
+    @pytest.mark.asyncio
+    async def test_invalid_transition_returns_400(self, fake_redis):
+        """If sm.transition() raises ValueError, gate must return 400 (not 500).
+
+        Uses fakeredis with a direct HSET to force an invalid state (not in TRANSITIONS)
+        so that the state machine's own transition() raises ValueError without any mocking.
+        """
+        run_id = "gate-bad-transition-0001"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        # Force state machine into 'planning' (valid gate check via 409 would catch it)
+        # Instead, set current state to 'pending_approval' and transition target to
+        # a state that IS in pending_approval's allowed list — but use a non-existent
+        # action to get past the gate and hit the transition guard.
+        #
+        # The simplest path: set the state directly to something the SM won't allow
+        # transitioning from via 'pending_approval → done'. Actually that IS valid.
+        # So the only way to trigger ValueError is to have pending_approval try to
+        # transition to a state NOT in its allowed list. We do that by patching
+        # the TRANSITIONS dict for this one test.
+        await fake_redis.hset(sm._key, "state", "pending_approval")
+
+        from ml_engine.agent.state_machine import TRANSITIONS
+
+        # Temporarily remove 'done' from pending_approval's transitions so any
+        # approve attempt fails with ValueError.
+        original_transitions = list(TRANSITIONS["pending_approval"])
+        TRANSITIONS["pending_approval"] = [t for t in original_transitions if t != "done"]
+
+        try:
+            with _gate_patches(fake_redis)[0], _gate_patches(fake_redis)[1]:
+                from fastapi.testclient import TestClient
+
+                from api.app import app
+
+                with TestClient(app) as client:
+                    resp = client.post(f"/api/agent/gate/{run_id}/approve", json={"reason": ""})
+        finally:
+            TRANSITIONS["pending_approval"] = original_transitions
+
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Extends `POST /api/agent/gate/{run_id}/{action}` to handle both human gate states in the pipeline, closing the blocker where runs paused at `pending_contract_approval` had no way to advance.

**Pipeline gates (two checkpoints, one endpoint):**

| State | approve | reject |
|---|---|---|
| `pending_contract_approval` (start-of-pipeline) | → `auto_labeling` | → `cancelled` |
| `pending_approval` (end-of-pipeline) | → `done` | → `cancelled` |

**Pre-existing bug fixed:** `pending_approval` reject previously targeted `escalated`, which is not a valid transition per the state machine (`TRANSITIONS["pending_approval"]` = `["done", "teacher_training", "cancelled", "failed_unrecoverable"]`). Corrected to `cancelled`. The new gate tests caught this on the first run.

**Event naming:** contract approval publishes `contract_approved` — the exact event the Coordinator's system prompt listens for to begin dispatching pipeline stages.

Closes #52.

---

## What changed

### `api/routes/agent.py`

`human_gate` (lines 369–431) was a single `if current != "pending_approval"` guard. Now it branches on state:

```python
if current == "pending_approval":
    target_state = "done" if action == "approve" else "cancelled"
    event_type   = "gate_approved" if action == "approve" else "gate_rejected"
elif current == "pending_contract_approval":
    target_state = "auto_labeling" if action == "approve" else "cancelled"
    event_type   = "contract_approved" if action == "approve" else "contract_rejected"
else:
    raise HTTPException(409, ...)
```

### `tests/unit/api/test_agent_coordinator.py`

| Test | Covers |
|---|---|
|`test_invalid_action_returns_400`| action not in `("approve", "reject")` |
|`test_unknown_run_returns_404`| run not in Redis |
|`test_non_gate_state_returns_409` (x4)|planning/auto_labeling/teacher_training/done|
|`test_pending_approval_approve_transitions_to_done`|happy path|
|`test_pending_approval_reject_transitions_to_cancelled`|bug fix path|
|`test_pending_contract_approval_approve_transitions_to_auto_labeling`|new_feature|
|`test_pending_contract_approval_reject_transitions_to_cancelled`|new_feature|
|`test_contract_approval_publishes_contract_approved_event`|event type assertion|
|`test_contract_rejection_publishes_contract_rejected_event`|event type assertion|
|`test_invalid_transition_returns_400`|`sm.transition()` ValueError ->400|