### PR TITLE
feat: classify Coordinator crashes — transient → failed_retrying, permanent → failed_unrecoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.5] — 2026-04-29
+
+### Fixed
+
+- **Coordinator crash classification** — Coordinator task crashes are now classified as transient or permanent before deciding whether to retry. Transient infrastructure failures (`ConnectionError`, `TimeoutError`, `InterruptedError`, `redis.exceptions.ConnectionError/TimeoutError`) in states that allow it (`auto_labeling`, `teacher_training`, `student_distillation`) are routed to `failed_retrying` and the Coordinator is re-launched automatically. Permanent errors (logic bugs, bad input, etc.) and transient errors in non-retryable states go straight to `failed_unrecoverable`. Respects `budget.max_retries` (default 2).
+- **`TRANSIENT_EXCEPTION_TYPES` scope narrowed** — The constant previously included bare `OSError`, which would have misclassified `FileNotFoundError`, `PermissionError`, and `ChildProcessError` as retryable infrastructure failures. Now uses specific `OSError` subclasses only: `ConnectionError`, `TimeoutError`, `InterruptedError`.
+- **Coordinator stuck on `failed_retrying` transition failure** — If `sm.transition("failed_retrying")` itself fails (e.g., concurrent state change), the crash handler now falls through to `failed_unrecoverable` rather than returning silently and leaving the run stranded in a non-terminal state with no active Coordinator task.
+
+### Added
+
+- `_handle_coordinator_crash()` — module-level async function in `api/routes/agent.py` that encapsulates the crash-routing logic. Replaces the nested `_mark_failed()` inner function, eliminating a three-layer nesting and making the retry logic independently testable.
+- `_is_transient_exception()` — module-level helper that checks an exception against `core.constants.TRANSIENT_EXCEPTION_TYPES` and, via lazy import, `redis.exceptions.ConnectionError` / `TimeoutError`.
+- `TRANSIENT_EXCEPTION_TYPES` tuple in `core/constants.py` — single source of truth for which exception families count as transient infrastructure failures, importable by workers and the Coordinator in addition to the API layer.
+
+### Tests
+
+- `TestCrashClassification` added to `tests/unit/api/test_agent_coordinator.py` (13 tests): transient-in-retryable-state → `failed_retrying` + coordinator re-launch (3 states covered); transient-in-non-retryable-state → `failed_unrecoverable`; permanent error → `failed_unrecoverable`; retries-exhausted → `failed_unrecoverable`; error-message persisted on `failed_retrying`; `retry_count` incremented; `_is_transient_exception` for builtin types (Connection, Timeout, Interrupted, BrokenPipe, ConnectionReset); non-transient types including `OSError`, `FileNotFoundError`, `PermissionError`; second-crash-from-`failed_retrying` terminates at `failed_unrecoverable`; missing Redis key returns silently.
+
 ## [0.1.4] — 2026-04-28
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -252,18 +252,9 @@ and the audit, but each wants a callsite enumeration before shipping.
 ---
 
 
-### 20. Refine Coordinator crash classification (failed_retrying for transient errors)
+### ~~20. Refine Coordinator crash classification (failed_retrying for transient errors)~~
 
-All Coordinator crashes currently → `failed_unrecoverable` (shipped in #2). Transient
-failures (import errors, Redis connection reset, network timeout) should route to
-`failed_retrying` instead to allow automatic recovery. Needs: (a) classify the exception
-type at the `_on_done` site in `api/routes/agent.py`; (b) verify `failed_retrying` has a
-re-launch path back to an active state (current TRANSITIONS do; `_start_coordinator` is
-already idempotent). Full context in
-[docs/decisions/02-coordinator-crash-failed-unrecoverable.md](docs/decisions/02-coordinator-crash-failed-unrecoverable.md).
-
-**Depends on / blocked by:** TODO #1 (auto-resume infra) — retrying is only useful once a
-re-launched Coordinator can actually pick up the run.
+**Completed:** v0.1.5 (2026-04-29) — `_handle_coordinator_crash()` classifies exceptions as transient (`ConnectionError`, `TimeoutError`, `InterruptedError`, `redis.exceptions.ConnectionError/TimeoutError`) or permanent. Transient crashes in retryable states (`auto_labeling`, `teacher_training`, `student_distillation`) with retries remaining route to `failed_retrying` + Coordinator re-launch. Permanent errors and retries-exhausted go to `failed_unrecoverable`. `TRANSIENT_EXCEPTION_TYPES` in `core/constants.py` is the single source of truth. Also fixed: silent-return bug on `failed_retrying` transition failure now falls through to `failed_unrecoverable`. 13 new tests in `TestCrashClassification`. GitHub issue #53.
 
 ---
 

--- a/api/routes/agent.py
+++ b/api/routes/agent.py
@@ -22,11 +22,26 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from api.schemas import success_response
+from core.constants import TRANSIENT_EXCEPTION_TYPES
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/agent", tags=["agent"])
 ws_router = APIRouter(tags=["agent-ws"])
+
+
+def _is_transient_exception(exc: BaseException) -> bool:
+    """Return True if exc looks like a transient infrastructure failure."""
+    if isinstance(exc, TRANSIENT_EXCEPTION_TYPES):
+        return True
+    try:
+        import redis.exceptions as _rex
+
+        if isinstance(exc, (_rex.ConnectionError, _rex.TimeoutError)):
+            return True
+    except ImportError:
+        pass
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -66,6 +81,66 @@ class GateActionRequest(BaseModel):
 _coordinator_tasks: Dict[str, asyncio.Task] = {}
 
 
+async def _handle_coordinator_crash(
+    run_id: str,
+    exc: BaseException,
+    r: Any,
+    contract: Any,
+    contract_dict: Dict[str, Any],
+    transient: bool,
+) -> None:
+    """
+    Async crash handler scheduled by the _on_done task callback.
+
+    Routes the failure to failed_retrying (and re-launches the Coordinator)
+    when the exception is transient, the current state allows retrying, and
+    the retry budget is not exhausted. Falls back to failed_unrecoverable for
+    permanent errors, non-retryable states, and budget-exhausted runs.
+    """
+    from ml_engine.agent.state_machine import TRANSITIONS, StateMachine
+
+    sm = StateMachine(run_id=run_id, redis_async=r)
+    try:
+        current = await sm.current_state()
+    except KeyError:
+        logger.error("Coordinator crash handler: run %s state not found", run_id)
+        return
+
+    can_retry = (
+        transient
+        and "failed_retrying" in TRANSITIONS.get(current, [])
+        and await sm.retry_count() < contract.budget.max_retries
+    )
+
+    if can_retry:
+        try:
+            await sm.transition("failed_retrying", error_message=str(exc))
+            logger.info("Run %s: transient crash, will retry (%s)", run_id, exc)
+        except Exception as mark_err:
+            logger.error("Failed to mark run %s as failed_retrying: %s", run_id, mark_err)
+            # Fall through to failed_unrecoverable — leaving the run in a non-terminal
+            # state with no coordinator task would stall it indefinitely.
+            try:
+                await sm.transition("failed_unrecoverable", error_message=str(exc))
+            except Exception as final_err:
+                logger.error(
+                    "Failed to mark run %s as failed_unrecoverable after retry failure: %s",
+                    run_id,
+                    final_err,
+                )
+            return
+        _start_coordinator(run_id, contract_dict)
+    else:
+        try:
+            await sm.transition("failed_unrecoverable", error_message=str(exc))
+        except Exception as mark_err:
+            logger.error(
+                "Failed to mark run %s as failed_unrecoverable: %s",
+                run_id,
+                mark_err,
+            )
+
+
 def _start_coordinator(run_id: str, contract_dict: Dict[str, Any]) -> None:
     """
     Start Coordinator.run() as an asyncio background task.
@@ -82,7 +157,6 @@ def _start_coordinator(run_id: str, contract_dict: Dict[str, Any]) -> None:
     from ml_engine.agent.contracts import PipelineContract
     from ml_engine.agent.coordinator import Coordinator
     from ml_engine.agent.llm_client import LLMClient
-    from ml_engine.agent.state_machine import StateMachine
 
     r = _get_async_redis()
     contract = PipelineContract.from_dict(contract_dict)
@@ -115,20 +189,12 @@ def _start_coordinator(run_id: str, contract_dict: Dict[str, Any]) -> None:
         exc = t.exception()
         if exc:
             logger.error("Coordinator task for run %s failed: %s", run_id, exc)
-
-            async def _mark_failed() -> None:
-                try:
-                    await StateMachine(run_id=run_id, redis_async=r).transition(
-                        "failed_unrecoverable", error_message=str(exc)
-                    )
-                except Exception as mark_err:
-                    logger.error(
-                        "Failed to mark run %s as failed_unrecoverable: %s",
-                        run_id,
-                        mark_err,
-                    )
-
-            asyncio.create_task(_mark_failed(), name=f"coordinator-crash-{run_id[:8]}")
+            asyncio.create_task(
+                _handle_coordinator_crash(
+                    run_id, exc, r, contract, contract_dict, _is_transient_exception(exc)
+                ),
+                name=f"coordinator-crash-{run_id[:8]}",
+            )
         else:
             logger.info("Coordinator task for run %s completed", run_id)
 

--- a/core/constants.py
+++ b/core/constants.py
@@ -278,6 +278,28 @@ DEFAULT_SAM_LORA_CONFIG = {
 }
 
 # ============================================================================
+# Agent / Pipeline Error Classification
+# ============================================================================
+
+# Exception types that indicate a transient infrastructure failure (network
+# blip, Redis restart, worker OOM) rather than a logic bug. Used by the
+# Coordinator crash handler to decide whether to retry via failed_retrying
+# or to go straight to failed_unrecoverable.
+#
+# These are specific OSError subclasses, NOT OSError itself. Using the parent
+# OSError would catch FileNotFoundError, PermissionError, ChildProcessError,
+# etc. — permanent failures that should never trigger a retry.
+#
+# redis.exceptions are NOT included here because they require the redis
+# package to be imported, which would add a hard dependency to core/. The
+# crash handler checks those types separately via a lazy import.
+TRANSIENT_EXCEPTION_TYPES = (
+    ConnectionError,  # includes BrokenPipeError, ConnectionReset, ConnectionRefused
+    TimeoutError,  # system-level operation timeout
+    InterruptedError,  # EINTR — system call interrupted by a signal
+)
+
+# ============================================================================
 # Version Info
 # ============================================================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grounded-segment-anything"
-version = "0.1.4"
+version = "0.1.5"
 description = "ML platform: Grounding DINO + SAM for auto-labeling, training, and inference"
 requires-python = ">=3.10,<3.11"
 dependencies = [

--- a/tests/unit/api/test_agent_coordinator.py
+++ b/tests/unit/api/test_agent_coordinator.py
@@ -1,10 +1,11 @@
 """
 Unit tests for Coordinator lifecycle in api/routes/agent.py.
 
-Covers three behaviours:
+Covers four behaviours:
   1. _on_done crash → failed_unrecoverable (TODO #2)
   2. approve_plan idempotency (TODO #3)
   3. resume_orphaned_coordinators startup scan (TODO #1)
+  4. Crash classification: transient → failed_retrying, permanent → failed_unrecoverable
 """
 
 from __future__ import annotations
@@ -808,3 +809,272 @@ class TestHumanGate:
             TRANSITIONS["pending_approval"] = original_transitions
 
         assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Crash classification: transient vs permanent (#4)
+# ---------------------------------------------------------------------------
+
+
+class TestCrashClassification:
+    """Tests for _handle_coordinator_crash: transient vs permanent routing.
+
+    Calls _handle_coordinator_crash directly to avoid asyncio task scheduling
+    complexity and focus on the routing logic under each condition.
+    """
+
+    def _make_contract(self, max_retries: int = 2) -> MagicMock:
+        contract = MagicMock()
+        contract.budget.max_retries = max_retries
+        return contract
+
+    @pytest.mark.asyncio
+    async def test_transient_in_retryable_state_routes_to_failed_retrying(self, fake_redis):
+        """ConnectionError from auto_labeling → failed_retrying and coordinator re-launched."""
+        run_id = "crash-class-0001"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("auto_labeling")
+
+        with patch("api.routes.agent._start_coordinator") as mock_restart:
+            from api.routes.agent import _handle_coordinator_crash
+
+            await _handle_coordinator_crash(
+                run_id,
+                ConnectionError("redis gone"),
+                fake_redis,
+                self._make_contract(),
+                {},
+                transient=True,
+            )
+
+        assert await sm.current_state() == "failed_retrying"
+        mock_restart.assert_called_once_with(run_id, {})
+
+    @pytest.mark.asyncio
+    async def test_transient_in_non_retryable_state_routes_to_failed_unrecoverable(self, fake_redis):
+        """TimeoutError from planning → failed_unrecoverable (planning has no failed_retrying arc)."""
+        run_id = "crash-class-0002"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+
+        with patch("api.routes.agent._start_coordinator") as mock_restart:
+            from api.routes.agent import _handle_coordinator_crash
+
+            await _handle_coordinator_crash(
+                run_id,
+                TimeoutError("llm timeout"),
+                fake_redis,
+                self._make_contract(),
+                {},
+                transient=True,
+            )
+
+        assert await sm.current_state() == "failed_unrecoverable"
+        mock_restart.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_permanent_exception_routes_to_failed_unrecoverable(self, fake_redis):
+        """RuntimeError from teacher_training → failed_unrecoverable (not retried)."""
+        run_id = "crash-class-0003"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("teacher_training")
+
+        with patch("api.routes.agent._start_coordinator") as mock_restart:
+            from api.routes.agent import _handle_coordinator_crash
+
+            await _handle_coordinator_crash(
+                run_id,
+                RuntimeError("logic bug"),
+                fake_redis,
+                self._make_contract(),
+                {},
+                transient=False,
+            )
+
+        assert await sm.current_state() == "failed_unrecoverable"
+        mock_restart.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_retries_exhausted_routes_to_failed_unrecoverable(self, fake_redis):
+        """Transient error from auto_labeling with retry_count at max → failed_unrecoverable."""
+        run_id = "crash-class-0004"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("auto_labeling")
+        await fake_redis.hset(sm._key, "retry_count", "2")  # budget exhausted
+
+        with patch("api.routes.agent._start_coordinator") as mock_restart:
+            from api.routes.agent import _handle_coordinator_crash
+
+            await _handle_coordinator_crash(
+                run_id,
+                ConnectionError("redis gone"),
+                fake_redis,
+                self._make_contract(max_retries=2),
+                {},
+                transient=True,
+            )
+
+        assert await sm.current_state() == "failed_unrecoverable"
+        mock_restart.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_transient_sets_error_message_on_failed_retrying(self, fake_redis):
+        """The error message is persisted even when routing to failed_retrying."""
+        run_id = "crash-class-0005"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("teacher_training")
+
+        with patch("api.routes.agent._start_coordinator"):
+            from api.routes.agent import _handle_coordinator_crash
+
+            await _handle_coordinator_crash(
+                run_id,
+                ConnectionError("lost connection to worker"),
+                fake_redis,
+                self._make_contract(),
+                {},
+                transient=True,
+            )
+
+        data = await sm.load()
+        assert "lost connection to worker" in data["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_retry_increments_retry_count(self, fake_redis):
+        """Each failed_retrying transition increments retry_count in Redis."""
+        run_id = "crash-class-0006"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("auto_labeling")
+
+        with patch("api.routes.agent._start_coordinator"):
+            from api.routes.agent import _handle_coordinator_crash
+
+            await _handle_coordinator_crash(
+                run_id,
+                TimeoutError("worker timeout"),
+                fake_redis,
+                self._make_contract(),
+                {},
+                transient=True,
+            )
+
+        assert await sm.retry_count() == 1
+
+    def test_is_transient_exception_builtin_types(self):
+        from api.routes.agent import _is_transient_exception
+
+        assert _is_transient_exception(ConnectionError("gone"))
+        assert _is_transient_exception(TimeoutError("timed out"))
+        assert _is_transient_exception(InterruptedError("EINTR"))
+        # ConnectionError subtypes are also transient
+        assert _is_transient_exception(BrokenPipeError("pipe gone"))
+        assert _is_transient_exception(ConnectionResetError("reset"))
+
+    def test_is_transient_exception_non_transient_types(self):
+        from api.routes.agent import _is_transient_exception
+
+        assert not _is_transient_exception(RuntimeError("logic bug"))
+        assert not _is_transient_exception(ValueError("bad input"))
+        assert not _is_transient_exception(KeyError("missing key"))
+        # OSError itself is too broad — only specific subclasses are transient
+        assert not _is_transient_exception(OSError("generic os error"))
+        assert not _is_transient_exception(FileNotFoundError("model not found"))
+        assert not _is_transient_exception(PermissionError("cannot write checkpoint"))
+
+    @pytest.mark.asyncio
+    async def test_second_crash_from_failed_retrying_routes_to_failed_unrecoverable(self, fake_redis):
+        """If the re-launched coordinator crashes while the SM is in failed_retrying
+        (i.e. before it can advance to a work state), the handler must not loop —
+        failed_retrying has no self-arc, so can_retry is False and it transitions
+        to failed_unrecoverable."""
+        run_id = "crash-class-0008"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        # Simulate: first crash already put the run in failed_retrying
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("auto_labeling")
+        await sm.transition("failed_retrying", error_message="first crash")
+
+        with patch("api.routes.agent._start_coordinator") as mock_restart:
+            from api.routes.agent import _handle_coordinator_crash
+
+            await _handle_coordinator_crash(
+                run_id,
+                ConnectionError("second crash"),
+                fake_redis,
+                self._make_contract(),
+                {},
+                transient=True,
+            )
+
+        # failed_retrying has no self-arc, so the second crash must not retry again
+        assert await sm.current_state() == "failed_unrecoverable"
+        mock_restart.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_state_key_returns_silently(self, fake_redis):
+        """If the Redis key for the run doesn't exist, KeyError is caught and the
+        handler returns without raising."""
+        run_id = "crash-class-missing-key"
+        contract_mock = MagicMock()
+        contract_mock.budget.max_retries = 2
+
+        with patch("api.routes.agent._start_coordinator") as mock_restart:
+            from api.routes.agent import _handle_coordinator_crash
+
+            # No sm.initialize() — the key doesn't exist in Redis
+            await _handle_coordinator_crash(
+                run_id,
+                ConnectionError("redis gone"),
+                fake_redis,
+                contract_mock,
+                {},
+                transient=True,
+            )
+
+        mock_restart.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_student_distillation_transient_routes_to_failed_retrying(self, fake_redis):
+        """student_distillation is a retryable state too — symmetry check."""
+        run_id = "crash-class-0007"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("teacher_training")
+        await sm.transition("training_eval_gate")
+        await sm.transition("student_distillation")
+
+        contract_dict = {"id": "test-contract"}
+        with patch("api.routes.agent._start_coordinator") as mock_restart:
+            from api.routes.agent import _handle_coordinator_crash
+
+            await _handle_coordinator_crash(
+                run_id,
+                OSError("worker killed"),
+                fake_redis,
+                self._make_contract(),
+                contract_dict,
+                transient=True,
+            )
+
+        assert await sm.current_state() == "failed_retrying"
+        mock_restart.assert_called_once_with(run_id, contract_dict)


### PR DESCRIPTION
Transient infrastructure failures (ConnectionError, TimeoutError, InterruptedError, redis connection/timeout) in retryable states (auto_labeling, teacher_training, student_distillation) now route to failed_retrying and re-launch the Coordinator automatically. Permanent logic errors go straight to failed_unrecoverable.

Respects budget.max_retries (default 2). Second crash from failed_retrying state terminates at failed_unrecoverable (no self-arc in TRANSITIONS prevents looping). Silent-return bug on failed_retrying transition failure fixed: now falls through to failed_unrecoverable to avoid leaving the run stuck with no active coordinator.

TRANSIENT_EXCEPTION_TYPES in core/constants.py narrows to specific OSError subclasses (ConnectionError, TimeoutError, InterruptedError) — bare OSError would have misclassified FileNotFoundError and PermissionError as retryable.

13 new tests in TestCrashClassification. Closes #53.