### PR TITLE
v0.1.6 fix(agent): re-dispatch job on retry — closes failed_retrying stuck state (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] — 2026-05-02
+
+### Fixed
+
+- **`failed_retrying` stuck state** — When a job fails with retries remaining, `on_event` previously transitioned to `failed_retrying` and returned, leaving the run stranded with no active job and no event to wake the Coordinator. The handler now captures `failed_stage = current` before transitioning away, then executes the sequence `failed_stage → failed_retrying → failed_stage` and calls `DispatchStageTool.execute()` directly to re-enqueue the job. Dispatch failure or SM-transition failure both route to `failed_unrecoverable`. Original LLM-chosen `stage_dispatch_overrides` from `LoopState` are forwarded verbatim on retry.
+
+### Tests
+
+- **14 new tests in `TestRetryDispatch`** — cover all three retryable stages, exact stage-name forwarding, override propagation (including empty-dict-not-None boundary), retry_count bookkeeping across two consecutive retries, exhausted-budget boundary (last allowed retry still dispatches), dispatch failure → `failed_unrecoverable`, error_message persistence, and no-LLM-call invariant. GitHub issue #54.
+
 ## [0.1.5] — 2026-04-29
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -332,6 +332,20 @@ and the audit, but each wants a callsite enumeration before shipping.
 
 ---
 
+### 27. PEL replay on SIGKILL after `sm.transition("failed_retrying")` — wastes a retry slot
+
+**What:** In `on_event` `job_failed` handling, `sm.transition("failed_retrying")` is called before `sm.transition(failed_stage)`. If the coordinator process is SIGKILL'd (OOM-kill, host crash) between those two calls, the SM state is durably written as `"failed_retrying"` in Redis but the stream message was not yet ACKed. On restart, `StreamConsumer` PEL recovery replays the `job_failed` event with `current_state() == "failed_retrying"`. The handler then sets `failed_stage = "failed_retrying"` (wrong) and attempts `sm.transition("failed_retrying")` from `"failed_retrying"` — an invalid self-arc. The inner `except` catches it and routes to `failed_unrecoverable`, wasting the remaining retry budget.
+
+**Why:** Only triggered by hard kills (SIGKILL, OOM-kill, host crash), not graceful shutdown. Narrow window between two async calls.
+
+**Fix:** During `sm.transition("failed_retrying")`, store the captured `failed_stage` in the SM hash (e.g., `retry_work_stage` field). On `job_failed` replay, detect `current == "failed_retrying"` and recover `failed_stage` from that field rather than from `current`.
+
+**Context:** `on_event` job_failed handler at [ml_engine/agent/coordinator.py:460-512](ml_engine/agent/coordinator.py#L460-L512). PEL recovery in `StreamConsumer`.
+
+**Depends on / blocked by:** TODO #22 (now complete). Low urgency — only SIGKILL/OOM scenarios; graceful restarts are unaffected.
+
+---
+
 ## Completed
 
 One-line stubs for items that have shipped. Long-form context (what shipped,

--- a/TODOS.md
+++ b/TODOS.md
@@ -266,17 +266,9 @@ and the audit, but each wants a callsite enumeration before shipping.
 
 ---
 
-### 22. `failed_retrying` — no retry dispatch (stuck state)
+### ~~22. `failed_retrying` — no retry dispatch (stuck state)~~
 
-**What:** When a job fails and `retry_count < max_retries`, `on_event` transitions the SM to `failed_retrying` and returns ([coordinator.py:462-467](ml_engine/agent/coordinator.py#L462-L467)). Nothing dispatches a retry job. No event is published to trigger a re-dispatch. On restart, the Coordinator resumes and waits — but there is no pending event in the stream. The run is stuck in `failed_retrying` forever.
-
-**Why:** The transition to `failed_retrying` was added to allow retries, but the actual retry dispatch logic was never implemented.
-
-**Fix:** After `sm.transition("failed_retrying")`, publish a `retry_requested` event to the stream (`type`, `stage`, `run_id`, `retry_count`). The Coordinator's `on_event` handler picks it up on the next loop iteration, reads the last dispatched stage from `LoopState` or the SM metadata, and re-dispatches via `dispatch_stage`. Alternatively, the Coordinator can call `dispatch_stage` directly in the `job_failed` handler before returning (simpler, but skips the event log).
-
-**Context:** `on_event` job_failed branch at [ml_engine/agent/coordinator.py:461-468](ml_engine/agent/coordinator.py#L461-L468). `TRANSITIONS["failed_retrying"]` at [ml_engine/agent/state_machine.py:84-89](ml_engine/agent/state_machine.py#L84-L89).
-
-**Depends on / blocked by:** TODO #20 (crash classification) — the distinction between `failed_retrying` and `failed_unrecoverable` only matters once retry dispatch actually works.
+**Completed:** v0.1.6 (2026-05-02) — `on_event` now captures `failed_stage = current` before transitioning away, then executes `failed_stage → failed_retrying → failed_stage` and calls `DispatchStageTool.execute()` directly to re-enqueue the job. Dispatch failure or SM-transition failure both route to `failed_unrecoverable`. `LoopState.stage_dispatch_overrides` forwarded verbatim. 14 new tests in `TestRetryDispatch`. GitHub issue #54.
 
 ---
 

--- a/ml_engine/agent/coordinator.py
+++ b/ml_engine/agent/coordinator.py
@@ -480,8 +480,12 @@ class Coordinator:
                             "failed_unrecoverable",
                             error_message=f"retry dispatch setup failed: {exc}",
                         )
-                    except Exception:
-                        pass
+                    except Exception as mark_err:
+                        logger.error(
+                            "Run %s: could not mark failed_unrecoverable after re-entry failure: %s",
+                            self.run_id,
+                            mark_err,
+                        )
                     return
                 retry_context = RunContext(
                     run_id=self.run_id,
@@ -489,10 +493,26 @@ class Coordinator:
                     contract=self._contract.to_dict() if self._contract else None,
                 )
                 dispatch_tool = self._tools.get("dispatch_stage")
-                result = await dispatch_tool.execute(
-                    DispatchStageArgs(stage=failed_stage, overrides=state.stage_dispatch_overrides or {}),
-                    retry_context,
-                )
+                try:
+                    result = await dispatch_tool.execute(
+                        DispatchStageArgs(stage=failed_stage, overrides=state.stage_dispatch_overrides or {}),
+                        retry_context,
+                    )
+                except Exception as dispatch_exc:
+                    logger.error(
+                        "Run %s: dispatch_stage.execute() raised for stage %s: %s",
+                        self.run_id,
+                        failed_stage,
+                        dispatch_exc,
+                    )
+                    try:
+                        await sm.transition(
+                            "failed_unrecoverable",
+                            error_message=f"retry dispatch raised: {dispatch_exc}",
+                        )
+                    except Exception as mark_err:
+                        logger.error("Run %s: could not mark failed_unrecoverable: %s", self.run_id, mark_err)
+                    return
                 if not result.success:
                     logger.error(
                         "Run %s: retry dispatch failed for stage %s: %s",

--- a/ml_engine/agent/coordinator.py
+++ b/ml_engine/agent/coordinator.py
@@ -457,12 +457,56 @@ class Coordinator:
             logger.info("Run %s waiting for human input (%s), ignoring event", self.run_id, current)
             return
 
-        # Handle job_failed deterministically
+        # Handle job_failed deterministically — classify, increment retry_count, re-dispatch
         if event_type == "job_failed":
             retry_count = await sm.retry_count()
             max_retries = self._contract.budget.max_retries if self._contract else 2
+            failed_stage = current  # capture the work stage before transitioning away
             if retry_count < max_retries:
                 await sm.transition("failed_retrying", error_message=event.get("error"))
+                logger.info(
+                    "Run %s: job failed on %s (attempt %d/%d), re-dispatching",
+                    self.run_id,
+                    failed_stage,
+                    retry_count + 1,
+                    max_retries,
+                )
+                try:
+                    await sm.transition(failed_stage)
+                except Exception as exc:
+                    logger.error("Run %s: failed to re-enter stage %s: %s", self.run_id, failed_stage, exc)
+                    try:
+                        await sm.transition(
+                            "failed_unrecoverable",
+                            error_message=f"retry dispatch setup failed: {exc}",
+                        )
+                    except Exception:
+                        pass
+                    return
+                retry_context = RunContext(
+                    run_id=self.run_id,
+                    redis_url=os.environ.get("REDIS_URL", "redis://localhost:6379"),
+                    contract=self._contract.to_dict() if self._contract else None,
+                )
+                dispatch_tool = self._tools.get("dispatch_stage")
+                result = await dispatch_tool.execute(
+                    DispatchStageArgs(stage=failed_stage, overrides=state.stage_dispatch_overrides or {}),
+                    retry_context,
+                )
+                if not result.success:
+                    logger.error(
+                        "Run %s: retry dispatch failed for stage %s: %s",
+                        self.run_id,
+                        failed_stage,
+                        result.error,
+                    )
+                    try:
+                        await sm.transition(
+                            "failed_unrecoverable",
+                            error_message=f"retry dispatch failed: {result.error}",
+                        )
+                    except Exception as mark_err:
+                        logger.error("Run %s: could not mark failed_unrecoverable: %s", self.run_id, mark_err)
             else:
                 await sm.transition("failed_unrecoverable", error_message="max retries exhausted")
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grounded-segment-anything"
-version = "0.1.5"
+version = "0.1.6"
 description = "ML platform: Grounding DINO + SAM for auto-labeling, training, and inference"
 requires-python = ">=3.10,<3.11"
 dependencies = [

--- a/tests/unit/api/test_agent_coordinator.py
+++ b/tests/unit/api/test_agent_coordinator.py
@@ -1078,3 +1078,374 @@ class TestCrashClassification:
 
         assert await sm.current_state() == "failed_retrying"
         mock_restart.assert_called_once_with(run_id, contract_dict)
+
+
+# ---------------------------------------------------------------------------
+# Retry dispatch (issue #54)
+# ---------------------------------------------------------------------------
+
+
+class TestRetryDispatch:
+    """Tests for Coordinator.on_event job_failed branch re-dispatch logic.
+
+    Core invariants under test:
+    - failed_stage is captured BEFORE transitioning away (not after)
+    - SM ends in the original work stage after successful dispatch
+    - dispatch_stage.execute() is called exactly once with the correct stage name
+    - stage_dispatch_overrides from LoopState are forwarded verbatim (empty dict, not None)
+    - retry_count is incremented by exactly 1 per retry
+    - retries-exhausted path never calls dispatch and ends in failed_unrecoverable
+    - dispatch failure path ends in failed_unrecoverable
+    - error_message is stored in SM data (persisted at failed_retrying transition)
+    - no LLM call is made (job_failed is deterministic)
+    """
+
+    def _make_contract(self, max_retries: int = 2) -> MagicMock:
+        contract = MagicMock()
+        contract.budget.max_retries = max_retries
+        contract.to_dict.return_value = {"max_retries": max_retries}
+        return contract
+
+    async def _reach_stage(self, run_id: str, fake_redis, stage: str) -> "StateMachine":
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition(stage)
+        return sm
+
+    async def _reach_student_distillation(self, run_id: str, fake_redis) -> "StateMachine":
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("teacher_training")
+        await sm.transition("training_eval_gate")
+        await sm.transition("student_distillation")
+        return sm
+
+    # ------------------------------------------------------------------
+    # State sequence correctness
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_teacher_training_failure_final_state_is_teacher_training(self, fake_redis):
+        """After a successful retry dispatch, the SM must be back in teacher_training —
+        NOT stuck in failed_retrying. This catches the original bug (no re-dispatch)."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-seq-0001"
+        sm = await self._reach_stage(run_id, fake_redis, "teacher_training")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)):
+            await coordinator.on_event({"type": "job_failed", "error": "OOM"}, LoopState(run_id=run_id))
+
+        final = await sm.current_state()
+        assert final == "teacher_training", (
+            f"SM ended in {final!r} — re-dispatch did not return run to work stage"
+        )
+
+    @pytest.mark.asyncio
+    async def test_auto_labeling_failure_final_state_is_auto_labeling(self, fake_redis):
+        """Same invariant as above for auto_labeling."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-seq-0002"
+        sm = await self._reach_stage(run_id, fake_redis, "auto_labeling")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)):
+            await coordinator.on_event({"type": "job_failed", "error": "timeout"}, LoopState(run_id=run_id))
+
+        assert await sm.current_state() == "auto_labeling"
+
+    @pytest.mark.asyncio
+    async def test_student_distillation_failure_final_state_is_student_distillation(self, fake_redis):
+        """Same invariant for student_distillation."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-seq-0003"
+        sm = await self._reach_student_distillation(run_id, fake_redis)
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)):
+            await coordinator.on_event({"type": "job_failed", "error": "CUDA OOM"}, LoopState(run_id=run_id))
+
+        assert await sm.current_state() == "student_distillation"
+
+    # ------------------------------------------------------------------
+    # Dispatch called with the right stage — catches wrong-stage bugs
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_dispatch_receives_exact_failed_stage_name(self, fake_redis):
+        """dispatch_stage.execute() must receive the stage that was active at failure time,
+        not the transient failed_retrying state or any other value."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-stage-0001"
+        await self._reach_stage(run_id, fake_redis, "auto_labeling")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        captured_args = []
+        with patch.object(
+            dispatch_tool,
+            "execute",
+            side_effect=lambda args, ctx: captured_args.append(args) or ToolResult(success=True),
+        ):
+            await coordinator.on_event({"type": "job_failed", "error": "crash"}, LoopState(run_id=run_id))
+
+        assert len(captured_args) == 1, "dispatch must be called exactly once"
+        assert captured_args[0].stage == "auto_labeling", (
+            f"dispatched stage was {captured_args[0].stage!r}, expected 'auto_labeling'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_dispatch_called_exactly_once(self, fake_redis):
+        """dispatch_stage.execute() is called exactly once per job_failed event."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-count-0001"
+        await self._reach_stage(run_id, fake_redis, "teacher_training")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)) as mock_dispatch:
+            await coordinator.on_event({"type": "job_failed", "error": "crash"}, LoopState(run_id=run_id))
+
+        assert mock_dispatch.call_count == 1
+
+    # ------------------------------------------------------------------
+    # Overrides forwarding — catches None vs {} bug
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_overrides_forwarded_verbatim(self, fake_redis):
+        """LoopState.stage_dispatch_overrides must reach dispatch args unchanged."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-override-0001"
+        await self._reach_stage(run_id, fake_redis, "teacher_training")
+
+        overrides = {"lr": 0.001, "epochs": 5, "batch_size": 16}
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        captured = []
+        with patch.object(
+            dispatch_tool,
+            "execute",
+            side_effect=lambda args, ctx: captured.append(args) or ToolResult(success=True),
+        ):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "crash"},
+                LoopState(run_id=run_id, stage_dispatch_overrides=overrides),
+            )
+
+        assert captured[0].overrides == overrides
+
+    @pytest.mark.asyncio
+    async def test_empty_overrides_forwarded_as_empty_dict_not_none(self, fake_redis):
+        """When LoopState has no overrides, dispatch args.overrides must be {} not None.
+        This catches the `overrides=state.stage_dispatch_overrides or {}` guard."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-override-0002"
+        await self._reach_stage(run_id, fake_redis, "teacher_training")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        captured = []
+        with patch.object(
+            dispatch_tool,
+            "execute",
+            side_effect=lambda args, ctx: captured.append(args) or ToolResult(success=True),
+        ):
+            await coordinator.on_event({"type": "job_failed", "error": "crash"}, LoopState(run_id=run_id))
+
+        assert captured[0].overrides is not None, "overrides must not be None"
+        assert captured[0].overrides == {}
+
+    # ------------------------------------------------------------------
+    # retry_count bookkeeping
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_retry_count_increments_by_one(self, fake_redis):
+        """retry_count must go from 0 → 1 on first retry."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-count-0002"
+        sm = await self._reach_stage(run_id, fake_redis, "teacher_training")
+        assert await sm.retry_count() == 0
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)):
+            await coordinator.on_event({"type": "job_failed", "error": "crash"}, LoopState(run_id=run_id))
+
+        assert await sm.retry_count() == 1
+
+    @pytest.mark.asyncio
+    async def test_second_retry_increments_to_two(self, fake_redis):
+        """Second retry: retry_count goes from 1 → 2 (not reset, not double-incremented)."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-count-0003"
+        sm = await self._reach_stage(run_id, fake_redis, "teacher_training")
+        # Simulate first retry already happened
+        await sm.transition("failed_retrying", error_message="first failure")
+        await sm.transition("teacher_training")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract(max_retries=3))
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "second crash"}, LoopState(run_id=run_id)
+            )
+
+        assert await sm.retry_count() == 2
+
+    # ------------------------------------------------------------------
+    # Retries exhausted — must not dispatch
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_retries_exhausted_no_dispatch_ends_in_failed_unrecoverable(self, fake_redis):
+        """When retry_count >= max_retries, dispatch must NOT be called and SM
+        must end in failed_unrecoverable."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-exhaust-0001"
+        sm = await self._reach_stage(run_id, fake_redis, "teacher_training")
+        await fake_redis.hset(sm._key, "retry_count", "2")  # at budget limit
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract(max_retries=2))
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)) as mock_dispatch:
+            await coordinator.on_event({"type": "job_failed", "error": "crash"}, LoopState(run_id=run_id))
+
+        assert await sm.current_state() == "failed_unrecoverable"
+        mock_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_retry_count_one_below_max_still_dispatches(self, fake_redis):
+        """retry_count == max_retries - 1 must still dispatch (boundary: last allowed retry)."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-exhaust-0002"
+        sm = await self._reach_stage(run_id, fake_redis, "teacher_training")
+        await fake_redis.hset(sm._key, "retry_count", "1")  # one retry used, max is 2
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract(max_retries=2))
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)) as mock_dispatch:
+            await coordinator.on_event({"type": "job_failed", "error": "crash"}, LoopState(run_id=run_id))
+
+        assert await sm.current_state() == "teacher_training"
+        mock_dispatch.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # Dispatch failure path
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_dispatch_failure_ends_in_failed_unrecoverable(self, fake_redis):
+        """If dispatch_stage.execute() returns success=False, SM must end in
+        failed_unrecoverable (not stuck in a work stage or failed_retrying)."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-fail-0001"
+        sm = await self._reach_stage(run_id, fake_redis, "auto_labeling")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(
+            dispatch_tool, "execute", return_value=ToolResult(success=False, error="executor queue full")
+        ):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
+            )
+
+        assert await sm.current_state() == "failed_unrecoverable"
+
+    # ------------------------------------------------------------------
+    # Error message persistence
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_job_error_message_stored_in_sm(self, fake_redis):
+        """The error field from the job_failed event must be written to SM
+        (it is set during the failed_retrying transition)."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-err-0001"
+        sm = await self._reach_stage(run_id, fake_redis, "teacher_training")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "GPU out of memory: 24 GiB"},
+                LoopState(run_id=run_id),
+            )
+
+        data = await sm.load()
+        assert "GPU out of memory" in data.get("error_message", ""), (
+            "error_message not persisted in SM — failed_retrying transition must store it"
+        )
+
+    # ------------------------------------------------------------------
+    # No LLM call on job_failed (deterministic path)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_no_llm_call_on_job_failed(self, fake_redis):
+        """job_failed handling is fully deterministic — the LLM must never be invoked."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-llm-0001"
+        await self._reach_stage(run_id, fake_redis, "teacher_training")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with (
+            patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)),
+            patch.object(
+                coordinator._llm, "call", side_effect=AssertionError("LLM must not be called on job_failed")
+            ),
+        ):
+            # Would raise if LLM is invoked
+            await coordinator.on_event({"type": "job_failed", "error": "crash"}, LoopState(run_id=run_id))

--- a/tests/unit/api/test_agent_coordinator.py
+++ b/tests/unit/api/test_agent_coordinator.py
@@ -1425,6 +1425,27 @@ class TestRetryDispatch:
             "error_message not persisted in SM — failed_retrying transition must store it"
         )
 
+    @pytest.mark.asyncio
+    async def test_dispatch_execute_raises_ends_in_failed_unrecoverable(self, fake_redis):
+        """If dispatch_stage.execute() raises an exception (not just returns success=False),
+        the run must end in failed_unrecoverable — not stuck in the work stage."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+
+        run_id = "rd-raise-0001"
+        sm = await self._reach_stage(run_id, fake_redis, "auto_labeling")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", side_effect=RuntimeError("redis timeout")):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
+            )
+
+        assert await sm.current_state() == "failed_unrecoverable", (
+            "dispatch_stage.execute() raised but run was not marked failed_unrecoverable"
+        )
+
     # ------------------------------------------------------------------
     # No LLM call on job_failed (deterministic path)
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary:
`failed_retrying` stuck state fix (issue #54). When a training job failed with retries remaining, `on_event` transitioned to `failed_retrying` and returned — no job was re-dispatched, the run was stuck forever.

## Fix
`coordinator.py` now captures `failed_stage = current` before transitioning away, executes `failed_stage → failed_retrying → failed_stage`, then calls `DispatchStageTool.execute()` to re-enqueue the job. All failure modes (dispatch raises, dispatch returns `success=False`, SM re-entry fails) route to `failed_unrecoverable`.

## What changed:
- `ml_engine/agent/coordinator.py` — `on_event` `job_failed` branch
- `tests/unit/api/test_agent_coordinator.py` — 15 new tests in `TestRetryDispatch`(65 → 80 total)
- `CHANGELOG.md` — v0.1.6 entry
- `pyproject.toml` — version 0.1.5 → 0.1.6
- `TODOS.md` — 22 complete, 27 opened (PEL replay edge case, deferred)