### PR TITLE
68 failed retrying sigkill between transition and re dispatch wastes a retry slot pel replay bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.7] — 2026-05-03
+
+### Fixed
+
+- **PEL replay wastes a retry slot after SIGKILL** — If the coordinator process was killed (OOM-kill, host crash) between `sm.transition("failed_retrying")` and the subsequent re-dispatch call, the Redis Stream PEL replay would present the event again with `current_state() == "failed_retrying"`. The old handler treated `"failed_retrying"` as the failed stage name and attempted an invalid self-arc transition, routing to `failed_unrecoverable` and burning a retry slot. The fix: `retry_work_stage` is now stored atomically in SM metadata alongside the `failed_retrying` transition; on replay the handler detects `current == "failed_retrying"`, reads the stage back from metadata, skips the budget charge, and converges at the shared re-dispatch path. Missing or corrupt metadata routes to `failed_unrecoverable` with an error log instead of silently swallowing the exception.
+
+### Refactored
+
+- **`_handle_job_failed` extracted from `on_event`** — The `job_failed` branch of `on_event` is now a dedicated `_handle_job_failed(event, sm, state, current)` method, keeping `on_event` readable and making the two-path logic (fresh retry vs. PEL replay) explicit.
+
+### Tests
+
+- **14 new tests in `TestRetryDispatch`** — cover the PEL replay path: correct stage recovery (not `"failed_retrying"`), retry-count not double-charged, budget double-charge regression guard (max_retries=2 boundary), missing/empty/corrupt/wrong-key metadata → `failed_unrecoverable`, dispatch raises → `failed_unrecoverable`, SM re-entry transition raises → `failed_unrecoverable`, all three retryable stages (`auto_labeling`, `teacher_training`, `student_distillation`), override forwarding, and no-LLM-call invariant. TODO #27.
+
 ## [0.1.6] — 2026-05-02
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -332,17 +332,9 @@ and the audit, but each wants a callsite enumeration before shipping.
 
 ---
 
-### 27. PEL replay on SIGKILL after `sm.transition("failed_retrying")` — wastes a retry slot
+### ~~27. PEL replay on SIGKILL after `sm.transition("failed_retrying")` — wastes a retry slot~~
 
-**What:** In `on_event` `job_failed` handling, `sm.transition("failed_retrying")` is called before `sm.transition(failed_stage)`. If the coordinator process is SIGKILL'd (OOM-kill, host crash) between those two calls, the SM state is durably written as `"failed_retrying"` in Redis but the stream message was not yet ACKed. On restart, `StreamConsumer` PEL recovery replays the `job_failed` event with `current_state() == "failed_retrying"`. The handler then sets `failed_stage = "failed_retrying"` (wrong) and attempts `sm.transition("failed_retrying")` from `"failed_retrying"` — an invalid self-arc. The inner `except` catches it and routes to `failed_unrecoverable`, wasting the remaining retry budget.
-
-**Why:** Only triggered by hard kills (SIGKILL, OOM-kill, host crash), not graceful shutdown. Narrow window between two async calls.
-
-**Fix:** During `sm.transition("failed_retrying")`, store the captured `failed_stage` in the SM hash (e.g., `retry_work_stage` field). On `job_failed` replay, detect `current == "failed_retrying"` and recover `failed_stage` from that field rather than from `current`.
-
-**Context:** `on_event` job_failed handler at [ml_engine/agent/coordinator.py:460-512](ml_engine/agent/coordinator.py#L460-L512). PEL recovery in `StreamConsumer`.
-
-**Depends on / blocked by:** TODO #22 (now complete). Low urgency — only SIGKILL/OOM scenarios; graceful restarts are unaffected.
+**Completed:** v0.1.7 (2026-05-03) — Extracted `_handle_job_failed()` from `on_event`. Fresh path stores `retry_work_stage` atomically in SM metadata alongside the `failed_retrying` transition. PEL replay path detects `current == "failed_retrying"`, reads `retry_work_stage` back from `sm.load()`, skips budget charge, and converges at shared re-dispatch block. Missing or corrupt metadata routes to `failed_unrecoverable` with an error log. 14 new tests in `TestRetryDispatch` covering corrupt/missing/wrong metadata, dispatch raises, SM re-entry raises, all three stages, and budget double-charge regression.
 
 ---
 

--- a/ml_engine/agent/coordinator.py
+++ b/ml_engine/agent/coordinator.py
@@ -594,8 +594,12 @@ class Coordinator:
                         "failed_unrecoverable",
                         error_message="PEL replay: retry_work_stage missing from SM metadata",
                     )
-                except Exception:
-                    pass
+                except Exception as mark_err:
+                    logger.error(
+                        "Run %s: could not mark failed_unrecoverable after missing metadata: %s",
+                        self.run_id,
+                        mark_err,
+                    )
                 return
             logger.info(
                 "Run %s: PEL replay — resuming re-dispatch of %s from failed_retrying",

--- a/ml_engine/agent/coordinator.py
+++ b/ml_engine/agent/coordinator.py
@@ -50,6 +50,14 @@ logger = logging.getLogger(__name__)
 # Stages that need a human gate before proceeding
 HUMAN_GATE_STAGES = {"pending_contract_approval", "pending_approval"}
 
+# Work stages that can fail and retry (have a "failed_retrying" arc in the SM graph).
+_RETRYABLE_WORK_STAGES: frozenset[str] = frozenset(
+    {"auto_labeling", "teacher_training", "student_distillation"}
+)
+
+# SM metadata key written atomically with failed_retrying so PEL replay can recover the stage.
+_RETRY_WORK_STAGE_KEY: str = "retry_work_stage"
+
 # Map pipeline state -> skill file name for per-stage LLM prompts.
 # SkillLoader reads configs/agent/skills/{name}.md.
 _STATE_TO_SKILL = {
@@ -583,8 +591,8 @@ class Coordinator:
                 meta = json.loads(data.get("metadata") or "{}")
             except (json.JSONDecodeError, TypeError):
                 meta = {}
-            failed_stage = meta.get("retry_work_stage")
-            if not failed_stage:
+            failed_stage = meta.get(_RETRY_WORK_STAGE_KEY)
+            if not failed_stage or failed_stage not in _RETRYABLE_WORK_STAGES:
                 logger.error(
                     "Run %s: PEL replay in failed_retrying but retry_work_stage missing from metadata",
                     self.run_id,
@@ -592,11 +600,11 @@ class Coordinator:
                 try:
                     await sm.transition(
                         "failed_unrecoverable",
-                        error_message="PEL replay: retry_work_stage missing from SM metadata",
+                        error_message="PEL replay: retry_work_stage missing or invalid in SM metadata",
                     )
                 except Exception as mark_err:
                     logger.error(
-                        "Run %s: could not mark failed_unrecoverable after missing metadata: %s",
+                        "Run %s: could not mark failed_unrecoverable after missing/invalid metadata: %s",
                         self.run_id,
                         mark_err,
                     )
@@ -609,17 +617,33 @@ class Coordinator:
         else:
             # Fresh job_failed from a retryable work stage.
             retry_count = await sm.retry_count()
-            max_retries = self._contract.budget.max_retries if self._contract else 2
+            max_retries = self._contract.budget.max_retries if self._contract else BudgetSpec().max_retries
             failed_stage = current
             if retry_count >= max_retries:
                 await sm.transition("failed_unrecoverable", error_message="max retries exhausted")
                 return
             # Store failed_stage atomically so this handler can recover the stage on PEL replay.
-            await sm.transition(
-                "failed_retrying",
-                error_message=event.get("error"),
-                metadata={"retry_work_stage": failed_stage},
-            )
+            try:
+                await sm.transition(
+                    "failed_retrying",
+                    error_message=event.get("error"),
+                    metadata={_RETRY_WORK_STAGE_KEY: failed_stage},
+                )
+            except Exception as exc:
+                logger.error(
+                    "Run %s: could not transition to failed_retrying from %s: %s",
+                    self.run_id,
+                    failed_stage,
+                    exc,
+                )
+                try:
+                    await sm.transition(
+                        "failed_unrecoverable",
+                        error_message=f"failed_retrying transition failed: {exc}",
+                    )
+                except Exception as mark_err:
+                    logger.error("Run %s: could not mark failed_unrecoverable: %s", self.run_id, mark_err)
+                return
             logger.info(
                 "Run %s: job failed on %s (attempt %d/%d), re-dispatching",
                 self.run_id,

--- a/ml_engine/agent/coordinator.py
+++ b/ml_engine/agent/coordinator.py
@@ -457,78 +457,8 @@ class Coordinator:
             logger.info("Run %s waiting for human input (%s), ignoring event", self.run_id, current)
             return
 
-        # Handle job_failed deterministically — classify, increment retry_count, re-dispatch
         if event_type == "job_failed":
-            retry_count = await sm.retry_count()
-            max_retries = self._contract.budget.max_retries if self._contract else 2
-            failed_stage = current  # capture the work stage before transitioning away
-            if retry_count < max_retries:
-                await sm.transition("failed_retrying", error_message=event.get("error"))
-                logger.info(
-                    "Run %s: job failed on %s (attempt %d/%d), re-dispatching",
-                    self.run_id,
-                    failed_stage,
-                    retry_count + 1,
-                    max_retries,
-                )
-                try:
-                    await sm.transition(failed_stage)
-                except Exception as exc:
-                    logger.error("Run %s: failed to re-enter stage %s: %s", self.run_id, failed_stage, exc)
-                    try:
-                        await sm.transition(
-                            "failed_unrecoverable",
-                            error_message=f"retry dispatch setup failed: {exc}",
-                        )
-                    except Exception as mark_err:
-                        logger.error(
-                            "Run %s: could not mark failed_unrecoverable after re-entry failure: %s",
-                            self.run_id,
-                            mark_err,
-                        )
-                    return
-                retry_context = RunContext(
-                    run_id=self.run_id,
-                    redis_url=os.environ.get("REDIS_URL", "redis://localhost:6379"),
-                    contract=self._contract.to_dict() if self._contract else None,
-                )
-                dispatch_tool = self._tools.get("dispatch_stage")
-                try:
-                    result = await dispatch_tool.execute(
-                        DispatchStageArgs(stage=failed_stage, overrides=state.stage_dispatch_overrides or {}),
-                        retry_context,
-                    )
-                except Exception as dispatch_exc:
-                    logger.error(
-                        "Run %s: dispatch_stage.execute() raised for stage %s: %s",
-                        self.run_id,
-                        failed_stage,
-                        dispatch_exc,
-                    )
-                    try:
-                        await sm.transition(
-                            "failed_unrecoverable",
-                            error_message=f"retry dispatch raised: {dispatch_exc}",
-                        )
-                    except Exception as mark_err:
-                        logger.error("Run %s: could not mark failed_unrecoverable: %s", self.run_id, mark_err)
-                    return
-                if not result.success:
-                    logger.error(
-                        "Run %s: retry dispatch failed for stage %s: %s",
-                        self.run_id,
-                        failed_stage,
-                        result.error,
-                    )
-                    try:
-                        await sm.transition(
-                            "failed_unrecoverable",
-                            error_message=f"retry dispatch failed: {result.error}",
-                        )
-                    except Exception as mark_err:
-                        logger.error("Run %s: could not mark failed_unrecoverable: %s", self.run_id, mark_err)
-            else:
-                await sm.transition("failed_unrecoverable", error_message="max retries exhausted")
+            await self._handle_job_failed(event, sm, state, current)
             return
 
         context = RunContext(
@@ -637,6 +567,122 @@ class Coordinator:
             logger.warning("No response from LLM for run %s on event %s", self.run_id, event_type)
         elif response.get("stop_reason") == "end_turn":
             logger.info("Coordinator done for event %s (run %s)", event_type, self.run_id)
+
+    async def _handle_job_failed(
+        self,
+        event: Dict[str, Any],
+        sm: StateMachine,
+        state: LoopState,
+        current: str,
+    ) -> None:
+        if current == "failed_retrying":
+            # PEL replay: coordinator crashed after persisting failed_retrying but before
+            # completing re-dispatch. Recover the original work stage from SM metadata.
+            data = await sm.load()
+            try:
+                meta = json.loads(data.get("metadata") or "{}")
+            except (json.JSONDecodeError, TypeError):
+                meta = {}
+            failed_stage = meta.get("retry_work_stage")
+            if not failed_stage:
+                logger.error(
+                    "Run %s: PEL replay in failed_retrying but retry_work_stage missing from metadata",
+                    self.run_id,
+                )
+                try:
+                    await sm.transition(
+                        "failed_unrecoverable",
+                        error_message="PEL replay: retry_work_stage missing from SM metadata",
+                    )
+                except Exception:
+                    pass
+                return
+            logger.info(
+                "Run %s: PEL replay — resuming re-dispatch of %s from failed_retrying",
+                self.run_id,
+                failed_stage,
+            )
+        else:
+            # Fresh job_failed from a retryable work stage.
+            retry_count = await sm.retry_count()
+            max_retries = self._contract.budget.max_retries if self._contract else 2
+            failed_stage = current
+            if retry_count >= max_retries:
+                await sm.transition("failed_unrecoverable", error_message="max retries exhausted")
+                return
+            # Store failed_stage atomically so this handler can recover the stage on PEL replay.
+            await sm.transition(
+                "failed_retrying",
+                error_message=event.get("error"),
+                metadata={"retry_work_stage": failed_stage},
+            )
+            logger.info(
+                "Run %s: job failed on %s (attempt %d/%d), re-dispatching",
+                self.run_id,
+                failed_stage,
+                retry_count + 1,
+                max_retries,
+            )
+
+        # Shared re-dispatch path — reached by both fresh retries and PEL replays.
+        try:
+            await sm.transition(failed_stage)
+        except Exception as exc:
+            logger.error("Run %s: failed to re-enter stage %s: %s", self.run_id, failed_stage, exc)
+            try:
+                await sm.transition(
+                    "failed_unrecoverable",
+                    error_message=f"retry dispatch setup failed: {exc}",
+                )
+            except Exception as mark_err:
+                logger.error(
+                    "Run %s: could not mark failed_unrecoverable after re-entry failure: %s",
+                    self.run_id,
+                    mark_err,
+                )
+            return
+
+        retry_context = RunContext(
+            run_id=self.run_id,
+            redis_url=os.environ.get("REDIS_URL", "redis://localhost:6379"),
+            contract=self._contract.to_dict() if self._contract else None,
+        )
+        dispatch_tool = self._tools.get("dispatch_stage")
+        try:
+            result = await dispatch_tool.execute(
+                DispatchStageArgs(stage=failed_stage, overrides=state.stage_dispatch_overrides or {}),
+                retry_context,
+            )
+        except Exception as dispatch_exc:
+            logger.error(
+                "Run %s: dispatch_stage.execute() raised for stage %s: %s",
+                self.run_id,
+                failed_stage,
+                dispatch_exc,
+            )
+            try:
+                await sm.transition(
+                    "failed_unrecoverable",
+                    error_message=f"retry dispatch raised: {dispatch_exc}",
+                )
+            except Exception as mark_err:
+                logger.error("Run %s: could not mark failed_unrecoverable: %s", self.run_id, mark_err)
+            return
+
+        if not result.success:
+            logger.error(
+                "Run %s: retry dispatch failed for stage %s: %s",
+                self.run_id,
+                failed_stage,
+                result.error,
+            )
+            try:
+                await sm.transition(
+                    "failed_unrecoverable",
+                    error_message=f"retry dispatch failed: {result.error}",
+                )
+            except Exception as mark_err:
+                logger.error("Run %s: could not mark failed_unrecoverable: %s", self.run_id, mark_err)
 
     async def run(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grounded-segment-anything"
-version = "0.1.6"
+version = "0.1.7"
 description = "ML platform: Grounding DINO + SAM for auto-labeling, training, and inference"
 requires-python = ">=3.10,<3.11"
 dependencies = [

--- a/tests/unit/api/test_agent_coordinator.py
+++ b/tests/unit/api/test_agent_coordinator.py
@@ -1470,3 +1470,397 @@ class TestRetryDispatch:
         ):
             # Would raise if LLM is invoked
             await coordinator.on_event({"type": "job_failed", "error": "crash"}, LoopState(run_id=run_id))
+
+    # ------------------------------------------------------------------
+    # PEL replay — coordinator crashed after failed_retrying, before re-dispatch
+    # ------------------------------------------------------------------
+
+    async def _reach_failed_retrying(
+        self,
+        run_id: str,
+        fake_redis,
+        work_stage: str,
+        *,
+        metadata: dict | None = ...,  # type: ignore[assignment]
+    ) -> "StateMachine":
+        """Put a run into failed_retrying, optionally with custom metadata."""
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        if work_stage == "student_distillation":
+            await sm.transition("teacher_training")
+            await sm.transition("training_eval_gate")
+        await sm.transition(work_stage)
+        if metadata is ...:
+            metadata = {"retry_work_stage": work_stage}
+        await sm.transition("failed_retrying", error_message="worker died", metadata=metadata)
+        return sm
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_dispatches_correct_stage_not_failed_retrying(self, fake_redis):
+        """Critical: PEL replay must dispatch to the ORIGINAL work stage, not to
+        'failed_retrying' (the SM state at replay time). A naive implementation that
+        reads `current` instead of SM metadata would dispatch to 'failed_retrying',
+        which is an invalid work stage."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0001"
+        await self._reach_failed_retrying(run_id, fake_redis, "teacher_training")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        captured_args = []
+        with patch.object(
+            dispatch_tool,
+            "execute",
+            side_effect=lambda args, ctx: captured_args.append(args) or ToolResult(success=True),
+        ):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
+            )
+
+        assert len(captured_args) == 1, "dispatch must be called exactly once"
+        assert captured_args[0].stage == "teacher_training", (
+            f"PEL replay dispatched to {captured_args[0].stage!r} — "
+            "must be 'teacher_training', not 'failed_retrying'"
+        )
+        assert captured_args[0].stage != "failed_retrying", (
+            "dispatched to 'failed_retrying' — implementation used `current` instead of metadata"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_final_state_is_work_stage_not_failed_retrying(self, fake_redis):
+        """After PEL replay, SM must be in the original work stage — not stuck in
+        failed_retrying. Catches the original no-dispatch bug on the replay path."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0002"
+        sm = await self._reach_failed_retrying(run_id, fake_redis, "auto_labeling")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
+            )
+
+        final = await sm.current_state()
+        assert final == "auto_labeling", (
+            f"SM ended in {final!r} after PEL replay — must return to 'auto_labeling'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_retry_count_not_incremented_second_time(self, fake_redis):
+        """retry_count must NOT increase on PEL replay. The budget was already charged
+        when failed_retrying was first stored. A second increment would exhaust the
+        budget after one real failure instead of max_retries. Concretely: retry_count
+        must be exactly the same before and after the replay event."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0003"
+        sm = await self._reach_failed_retrying(run_id, fake_redis, "teacher_training")
+        retry_count_before = await sm.retry_count()  # should be 1 after failed_retrying transition
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
+            )
+
+        retry_count_after = await sm.retry_count()
+        assert retry_count_after == retry_count_before, (
+            f"PEL replay incremented retry_count {retry_count_before} → {retry_count_after}. "
+            "Budget must only be charged once, not again on replay."
+        )
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_budget_not_double_charged_with_max_retries_two(self, fake_redis):
+        """Regression guard: with max_retries=2, a single real failure followed by
+        PEL replay must still dispatch (retry_count is 1, budget is 2). If the replay
+        path re-charges the budget, retry_count becomes 2 and the run is incorrectly
+        terminated as exhausted."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0004"
+        sm = await self._reach_failed_retrying(run_id, fake_redis, "auto_labeling")
+        # retry_count is 1 after the first failed_retrying transition; budget is 2.
+        assert await sm.retry_count() == 1
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract(max_retries=2))
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)) as mock_dispatch:
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
+            )
+
+        # Must dispatch — budget not yet exhausted.
+        mock_dispatch.assert_called_once()
+        final = await sm.current_state()
+        assert final == "auto_labeling", (
+            f"PEL replay ended in {final!r}. If retry_count was double-charged, "
+            "the run was incorrectly sent to failed_unrecoverable."
+        )
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_no_metadata_field_ends_in_failed_unrecoverable(self, fake_redis):
+        """SM is in failed_retrying with no metadata field at all (e.g. first-gen
+        coordinator that predates this fix, or manual state injection). Handler must
+        route to failed_unrecoverable — not crash or dispatch to None."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0005"
+        sm = await self._reach_failed_retrying(run_id, fake_redis, "teacher_training", metadata=None)
+
+        # Confirm no metadata was written.
+        data = await sm.load()
+        assert not data.get("metadata"), "precondition: no metadata in SM"
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)) as mock_dispatch:
+            await coordinator.on_event({"type": "job_failed", "error": "injected"}, LoopState(run_id=run_id))
+
+        assert await sm.current_state() == "failed_unrecoverable"
+        mock_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_empty_metadata_dict_ends_in_failed_unrecoverable(self, fake_redis):
+        """SM is in failed_retrying with metadata='{}' (valid JSON, no retry_work_stage key).
+        Handler must route to failed_unrecoverable — meta.get('retry_work_stage') returns
+        None which is falsy; must not dispatch with stage=None."""
+        import json
+
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0006"
+        sm = await self._reach_failed_retrying(run_id, fake_redis, "teacher_training", metadata={})
+
+        # The `if metadata:` guard in _build_transition_updates skips empty dicts.
+        # Manually inject empty JSON to simulate the corner case.
+        await fake_redis.hset(sm._key, "metadata", json.dumps({}))
+        data = await sm.load()
+        assert json.loads(data["metadata"]) == {}, "precondition: metadata is empty dict"
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)) as mock_dispatch:
+            await coordinator.on_event({"type": "job_failed", "error": "injected"}, LoopState(run_id=run_id))
+
+        assert await sm.current_state() == "failed_unrecoverable"
+        mock_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_corrupt_json_metadata_ends_in_failed_unrecoverable(self, fake_redis):
+        """SM metadata field is not valid JSON (storage corruption). Handler must survive
+        json.loads failure and route to failed_unrecoverable, not crash or hang."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0007"
+        sm = await self._reach_failed_retrying(run_id, fake_redis, "teacher_training", metadata=None)
+        # Inject corrupt JSON directly into Redis.
+        await fake_redis.hset(sm._key, "metadata", b"{{not-valid-json::}")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)) as mock_dispatch:
+            await coordinator.on_event({"type": "job_failed", "error": "injected"}, LoopState(run_id=run_id))
+
+        assert await sm.current_state() == "failed_unrecoverable"
+        mock_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_wrong_metadata_key_ends_in_failed_unrecoverable(self, fake_redis):
+        """Metadata has valid JSON but an unexpected key (e.g. 'stage' instead of
+        'retry_work_stage'). Catches typos in the key name on either side of the
+        write/read pair."""
+        import json
+
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0008"
+        sm = await self._reach_failed_retrying(run_id, fake_redis, "teacher_training", metadata=None)
+        # Wrong key — simulates a key name mismatch between writer and reader.
+        await fake_redis.hset(sm._key, "metadata", json.dumps({"stage": "teacher_training"}))
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)) as mock_dispatch:
+            await coordinator.on_event({"type": "job_failed", "error": "injected"}, LoopState(run_id=run_id))
+
+        assert await sm.current_state() == "failed_unrecoverable"
+        mock_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_dispatch_failure_ends_in_failed_unrecoverable(self, fake_redis):
+        """On PEL replay, if dispatch returns success=False the run must end in
+        failed_unrecoverable — not stuck in the work stage."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0009"
+        sm = await self._reach_failed_retrying(run_id, fake_redis, "auto_labeling")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(
+            dispatch_tool,
+            "execute",
+            return_value=ToolResult(success=False, error="executor queue full"),
+        ):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
+            )
+
+        assert await sm.current_state() == "failed_unrecoverable"
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_dispatch_raises_ends_in_failed_unrecoverable(self, fake_redis):
+        """On PEL replay, if dispatch_stage.execute() raises (network failure, etc.)
+        the run must end in failed_unrecoverable — not stuck in a work stage."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+
+        run_id = "rd-pel-0010"
+        sm = await self._reach_failed_retrying(run_id, fake_redis, "teacher_training")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with patch.object(dispatch_tool, "execute", side_effect=RuntimeError("redis connection lost")):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
+            )
+
+        assert await sm.current_state() == "failed_unrecoverable"
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_sm_reentry_transition_raises_ends_in_failed_unrecoverable(self, fake_redis):
+        """On PEL replay, if sm.transition(failed_stage) raises (concurrent state change
+        between load() and transition()), the run must end in failed_unrecoverable.
+        A broken implementation might silently return, leaving the run in failed_retrying."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0011"
+        sm = await self._reach_failed_retrying(run_id, fake_redis, "auto_labeling")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+
+        original_transition = StateMachine.transition
+
+        call_count = 0
+
+        async def patched_transition(self_sm, new_state, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            # Let load/other ops through; raise only on re-entry to work stage.
+            if new_state == "auto_labeling":
+                raise ValueError("concurrent state mutation")
+            return await original_transition(self_sm, new_state, **kwargs)
+
+        with (
+            patch.object(StateMachine, "transition", patched_transition),
+            patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)) as mock_dispatch,
+        ):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
+            )
+
+        assert await sm.current_state() == "failed_unrecoverable"
+        mock_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_student_distillation(self, fake_redis):
+        """PEL replay correctly recovers student_distillation stage (deeper path in SM)."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0012"
+        sm = await self._reach_failed_retrying(run_id, fake_redis, "student_distillation")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        captured_args = []
+        with patch.object(
+            dispatch_tool,
+            "execute",
+            side_effect=lambda args, ctx: captured_args.append(args) or ToolResult(success=True),
+        ):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
+            )
+
+        assert captured_args[0].stage == "student_distillation"
+        assert await sm.current_state() == "student_distillation"
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_overrides_forwarded_from_loop_state(self, fake_redis):
+        """On PEL replay the coordinator is restarted with a fresh LoopState (loaded
+        from Redis). Overrides on that LoopState must still reach the dispatch args."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0013"
+        await self._reach_failed_retrying(run_id, fake_redis, "teacher_training")
+
+        overrides = {"lr": 1e-4, "epochs": 10}
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        captured = []
+        with patch.object(
+            dispatch_tool,
+            "execute",
+            side_effect=lambda args, ctx: captured.append(args) or ToolResult(success=True),
+        ):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"},
+                LoopState(run_id=run_id, stage_dispatch_overrides=overrides),
+            )
+
+        assert captured[0].overrides == overrides
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_no_llm_call(self, fake_redis):
+        """PEL replay path is deterministic — LLM must never be invoked."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-pel-0014"
+        await self._reach_failed_retrying(run_id, fake_redis, "auto_labeling")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        with (
+            patch.object(dispatch_tool, "execute", return_value=ToolResult(success=True)),
+            patch.object(
+                coordinator._llm,
+                "call",
+                side_effect=AssertionError("LLM must not be called on PEL replay"),
+            ),
+        ):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
+            )

--- a/tests/unit/api/test_agent_coordinator.py
+++ b/tests/unit/api/test_agent_coordinator.py
@@ -1566,7 +1566,8 @@ class TestRetryDispatch:
 
         run_id = "rd-pel-0003"
         sm = await self._reach_failed_retrying(run_id, fake_redis, "teacher_training")
-        retry_count_before = await sm.retry_count()  # should be 1 after failed_retrying transition
+        retry_count_before = await sm.retry_count()
+        assert retry_count_before == 1, "precondition: retry_count must be 1 after failed_retrying"
 
         coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
         dispatch_tool = coordinator._tools.get("dispatch_stage")
@@ -1768,11 +1769,7 @@ class TestRetryDispatch:
 
         original_transition = StateMachine.transition
 
-        call_count = 0
-
         async def patched_transition(self_sm, new_state, **kwargs):
-            nonlocal call_count
-            call_count += 1
             # Let load/other ops through; raise only on re-entry to work stage.
             if new_state == "auto_labeling":
                 raise ValueError("concurrent state mutation")
@@ -1811,6 +1808,7 @@ class TestRetryDispatch:
                 {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
             )
 
+        assert len(captured_args) == 1, "dispatch must be called exactly once on PEL replay"
         assert captured_args[0].stage == "student_distillation"
         assert await sm.current_state() == "student_distillation"
 
@@ -1839,6 +1837,7 @@ class TestRetryDispatch:
                 LoopState(run_id=run_id, stage_dispatch_overrides=overrides),
             )
 
+        assert len(captured) == 1, "dispatch must be called exactly once on PEL replay"
         assert captured[0].overrides == overrides
 
     @pytest.mark.asyncio

--- a/tests/unit/api/test_agent_coordinator.py
+++ b/tests/unit/api/test_agent_coordinator.py
@@ -1890,3 +1890,221 @@ class TestRetryDispatch:
         assert final_state == "failed_unrecoverable", (
             f"gate-state job_failed ended in {final_state!r}; expected 'failed_unrecoverable'"
         )
+
+    @pytest.mark.asyncio
+    async def test_fresh_job_failed_from_label_review_gate_routes_to_failed_unrecoverable(self, fake_redis):
+        """label_review_gate has no 'failed_retrying' arc — must not propagate ValueError."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+
+        run_id = "rd-gate-0002"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("auto_labeling")
+        await sm.transition("label_review_gate")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        await coordinator.on_event(
+            {"type": "job_failed", "error": "labeler crashed"}, LoopState(run_id=run_id)
+        )
+
+        final_state = await sm.current_state()
+        assert final_state == "failed_unrecoverable", (
+            f"label_review_gate job_failed ended in {final_state!r}; expected 'failed_unrecoverable'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fresh_job_failed_from_distill_eval_gate_routes_to_failed_unrecoverable(self, fake_redis):
+        """distill_eval_gate has no 'failed_retrying' arc — must not propagate ValueError."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+
+        run_id = "rd-gate-0003"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("teacher_training")
+        await sm.transition("training_eval_gate")
+        await sm.transition("student_distillation")
+        await sm.transition("distill_eval_gate")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        await coordinator.on_event(
+            {"type": "job_failed", "error": "distill evaluator crashed"}, LoopState(run_id=run_id)
+        )
+
+        final_state = await sm.current_state()
+        assert final_state == "failed_unrecoverable", (
+            f"distill_eval_gate job_failed ended in {final_state!r}; expected 'failed_unrecoverable'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fresh_job_failed_from_gate_state_does_not_call_dispatch(self, fake_redis):
+        """Gate-state job_failed must never call dispatch_stage — there is no work to retry.
+        Naive implementation that reaches the shared dispatch block after a failed
+        failed_retrying transition would call dispatch with 'training_eval_gate'."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-gate-0004"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("teacher_training")
+        await sm.transition("training_eval_gate")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        dispatch_called = []
+        with patch.object(
+            dispatch_tool,
+            "execute",
+            side_effect=lambda args, ctx: dispatch_called.append(args) or ToolResult(success=True),
+        ):
+            await coordinator.on_event(
+                {"type": "job_failed", "error": "evaluator crashed"}, LoopState(run_id=run_id)
+            )
+
+        assert len(dispatch_called) == 0, (
+            f"dispatch_stage was called with {[a.stage for a in dispatch_called]!r}; "
+            "must not dispatch when job_failed arrives in a gate state"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fresh_job_failed_from_gate_state_does_not_increment_retry_count(self, fake_redis):
+        """Gate-state job_failed must not charge the retry budget.
+        The failure is in the Coordinator infrastructure (invalid state for retrying),
+        not in the worker — the retry slot must be preserved for real work failures."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+
+        run_id = "rd-gate-0005"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("teacher_training")
+        await sm.transition("training_eval_gate")
+
+        retry_count_before = await sm.retry_count()
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        await coordinator.on_event(
+            {"type": "job_failed", "error": "evaluator crashed"}, LoopState(run_id=run_id)
+        )
+        retry_count_after = await sm.retry_count()
+
+        assert retry_count_before == 0, "precondition: retry_count must be 0 before event"
+        assert retry_count_after == retry_count_before, (
+            f"retry_count went from {retry_count_before} to {retry_count_after}; "
+            "gate-state job_failed must not charge the retry budget"
+        )
+
+    # ------------------------------------------------------------------
+    # Bug 2: allowlist validation for retry_work_stage from Redis metadata
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_stage_not_in_allowlist_ends_in_failed_unrecoverable(self, fake_redis):
+        """retry_work_stage = 'training_eval_gate' stored in metadata must be rejected.
+        Old code only checked 'if not failed_stage' (truthy/falsy) — 'training_eval_gate'
+        is truthy so it would reach sm.transition(failed_stage) in the shared re-dispatch
+        block, which raises ValueError (no arc from failed_retrying to training_eval_gate).
+        The allowlist check catches it before any SM transition attempt."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+
+        run_id = "rd-allowlist-0001"
+        await self._reach_failed_retrying(
+            run_id,
+            fake_redis,
+            "teacher_training",
+            metadata={"retry_work_stage": "training_eval_gate"},
+        )
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        await coordinator.on_event({"type": "job_failed", "error": "replayed"}, LoopState(run_id=run_id))
+
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        assert await sm.current_state() == "failed_unrecoverable", (
+            "non-allowlist stage in metadata must end in 'failed_unrecoverable'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_failed_unrecoverable_in_metadata_does_not_dispatch(self, fake_redis):
+        """The critical allowlist case: retry_work_stage = 'failed_unrecoverable'.
+
+        'failed_unrecoverable' IS a valid arc in TRANSITIONS['failed_retrying'], so
+        the old code (only 'if not failed_stage') would:
+          1. accept it as truthy
+          2. sm.transition('failed_unrecoverable') — succeeds, valid arc in the SM graph
+          3. dispatch_stage('failed_unrecoverable') — dispatches a job to a terminal state
+
+        The allowlist rejects it before any SM write. Dispatch must never be called."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-allowlist-0002"
+        await self._reach_failed_retrying(
+            run_id,
+            fake_redis,
+            "auto_labeling",
+            metadata={"retry_work_stage": "failed_unrecoverable"},
+        )
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        dispatch_called = []
+        with patch.object(
+            dispatch_tool,
+            "execute",
+            side_effect=lambda args, ctx: dispatch_called.append(args) or ToolResult(success=True),
+        ):
+            await coordinator.on_event({"type": "job_failed", "error": "replayed"}, LoopState(run_id=run_id))
+
+        assert len(dispatch_called) == 0, (
+            f"dispatch_stage called with stage={dispatch_called[0].stage!r}; "
+            "old code would have dispatched a job to a terminal state via the valid arc"
+        )
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        assert await sm.current_state() == "failed_unrecoverable"
+
+    @pytest.mark.asyncio
+    async def test_pel_replay_failed_retrying_in_metadata_does_not_dispatch(self, fake_redis):
+        """retry_work_stage = 'failed_retrying' — the exact self-arc value the original
+        PEL bug (before this fix) would have written to Redis metadata, because the old
+        handler used 'failed_stage = current' where current == 'failed_retrying'.
+        Must be rejected by the allowlist and never reach dispatch."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+        from ml_engine.agent.tools import ToolResult
+
+        run_id = "rd-allowlist-0003"
+        await self._reach_failed_retrying(
+            run_id,
+            fake_redis,
+            "auto_labeling",
+            metadata={"retry_work_stage": "failed_retrying"},
+        )
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        dispatch_tool = coordinator._tools.get("dispatch_stage")
+        dispatch_called = []
+        with patch.object(
+            dispatch_tool,
+            "execute",
+            side_effect=lambda args, ctx: dispatch_called.append(args) or ToolResult(success=True),
+        ):
+            await coordinator.on_event({"type": "job_failed", "error": "replayed"}, LoopState(run_id=run_id))
+
+        assert len(dispatch_called) == 0, (
+            f"dispatch_stage called with stage={dispatch_called[0].stage!r}; "
+            "retry_work_stage='failed_retrying' is a self-arc and must be rejected by allowlist"
+        )
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        assert await sm.current_state() == "failed_unrecoverable"

--- a/tests/unit/api/test_agent_coordinator.py
+++ b/tests/unit/api/test_agent_coordinator.py
@@ -1493,7 +1493,9 @@ class TestRetryDispatch:
             await sm.transition("training_eval_gate")
         await sm.transition(work_stage)
         if metadata is ...:
-            metadata = {"retry_work_stage": work_stage}
+            from ml_engine.agent.coordinator import _RETRY_WORK_STAGE_KEY
+
+            metadata = {_RETRY_WORK_STAGE_KEY: work_stage}
         await sm.transition("failed_retrying", error_message="worker died", metadata=metadata)
         return sm
 
@@ -1524,11 +1526,8 @@ class TestRetryDispatch:
 
         assert len(captured_args) == 1, "dispatch must be called exactly once"
         assert captured_args[0].stage == "teacher_training", (
-            f"PEL replay dispatched to {captured_args[0].stage!r} — "
-            "must be 'teacher_training', not 'failed_retrying'"
-        )
-        assert captured_args[0].stage != "failed_retrying", (
-            "dispatched to 'failed_retrying' — implementation used `current` instead of metadata"
+            f"PEL replay dispatched to {captured_args[0].stage!r}; "
+            "must be 'teacher_training' — naive implementation would use 'failed_retrying'"
         )
 
     @pytest.mark.asyncio
@@ -1863,3 +1862,31 @@ class TestRetryDispatch:
             await coordinator.on_event(
                 {"type": "job_failed", "error": "worker died"}, LoopState(run_id=run_id)
             )
+
+    @pytest.mark.asyncio
+    async def test_fresh_job_failed_from_gate_state_routes_to_failed_unrecoverable(self, fake_redis):
+        """job_failed arriving when SM is in a gate/eval state (e.g. training_eval_gate)
+        must not propagate an unhandled ValueError. The gate states have no
+        'failed_retrying' arc in the SM — the handler must catch the transition
+        failure and route to failed_unrecoverable instead."""
+        from ml_engine.agent.coordinator import Coordinator
+        from ml_engine.agent.loop import LoopState
+
+        run_id = "rd-gate-0001"
+        sm = StateMachine(run_id=run_id, redis_async=fake_redis)
+        await sm.initialize()
+        await sm.transition("planning")
+        await sm.transition("pending_contract_approval")
+        await sm.transition("teacher_training")
+        await sm.transition("training_eval_gate")
+
+        coordinator = Coordinator(fake_redis, run_id, contract=self._make_contract())
+        # Must not raise — ValueError from sm.transition("failed_retrying") must be caught.
+        await coordinator.on_event(
+            {"type": "job_failed", "error": "evaluator crashed"}, LoopState(run_id=run_id)
+        )
+
+        final_state = await sm.current_state()
+        assert final_state == "failed_unrecoverable", (
+            f"gate-state job_failed ended in {final_state!r}; expected 'failed_unrecoverable'"
+        )


### PR DESCRIPTION
## Summary

This PR is to solve the issue proposed at https://github.com/hongthepotato/Grounded-Segment-Anything/issues/68

Fixes a PEL (Pending Entry List) replay bug where a coordinator SIGKILL between
`sm.transition("failed_retrying")` and re-dispatch permanently wasted a retry slot.

**Root cause:** Redis Streams deliver unACKed messages to the next consumer on restart
(PEL replay). The old handler always did `failed_stage = current`, so a replayed
`job_failed` event with `current == "failed_retrying"` would attempt
`sm.transition("failed_retrying")` from `"failed_retrying"` — an invalid self-arc.
The inner `except` caught it and routed to `failed_unrecoverable`, consuming the
retry budget for a crash that was never the worker's fault.

**Fix:** Store `retry_work_stage` atomically in SM metadata alongside the
`failed_retrying` transition (single `HSET` — no SIGKILL window between state and
metadata). On replay, detect `current == "failed_retrying"`, read the stage back
from metadata, skip the budget charge, and converge at the shared re-dispatch block.

Pre-landing review surfaced two additional bugs in the new code, fixed in the same PR:

- **Gate-state crash:** `job_failed` arriving when the SM is in a gate/eval state
  (`training_eval_gate`, `label_review_gate`, `distill_eval_gate`) would call
  `sm.transition("failed_retrying")` with no arc in the SM graph, propagating an
  unhandled `ValueError` that ACKed the message and permanently stuck the run with
  no error marking. Fixed by wrapping in try/except and routing to
  `failed_unrecoverable`.

- **Allowlist bypass:** `retry_work_stage` read from Redis was used without
  validating against the set of retryable stages. The critical case:
  `"failed_unrecoverable"` is a valid SM arc from `"failed_retrying"`, so the old
  check (`if not failed_stage`) would have let it through, called
  `sm.transition("failed_unrecoverable")` (succeeds), then
  `dispatch_stage("failed_unrecoverable")` — dispatching a job to a terminal state.
  Fixed by checking against `_RETRYABLE_WORK_STAGES` before any SM write.

## Changes

**`ml_engine/agent/coordinator.py`**
- Extract `_handle_job_failed(event, sm, state, current)` from `on_event`
- Add `_RETRYABLE_WORK_STAGES` frozenset and `_RETRY_WORK_STAGE_KEY` constant
- Fresh retry path: wrap `sm.transition("failed_retrying")` in try/except; gate
  states now route to `failed_unrecoverable` instead of propagating `ValueError`
- PEL replay path: validate `retry_work_stage` against `_RETRYABLE_WORK_STAGES`
  allowlist before any SM transition
- Replace magic `2` max-retries fallback with `BudgetSpec().max_retries`
- Add logging to previously silent `except Exception: pass` block

**`tests/unit/api/test_agent_coordinator.py`** (+7 tests, 80 → 102 total)

PEL replay (14 existing + bug regression):
- `test_pel_replay_stage_not_in_allowlist_ends_in_failed_unrecoverable`
- `test_pel_replay_failed_unrecoverable_in_metadata_does_not_dispatch`
- `test_pel_replay_failed_retrying_in_metadata_does_not_dispatch`

Gate-state crash (new):
- `test_fresh_job_failed_from_gate_state_routes_to_failed_unrecoverable` (training_eval_gate)
- `test_fresh_job_failed_from_label_review_gate_routes_to_failed_unrecoverable`
- `test_fresh_job_failed_from_distill_eval_gate_routes_to_failed_unrecoverable`
- `test_fresh_job_failed_from_gate_state_does_not_call_dispatch`
- `test_fresh_job_failed_from_gate_state_does_not_increment_retry_count`

**`TODOS.md`** — TODO 27 marked complete

**`CHANGELOG.md`** — v0.1.7 entry

**`pyproject.toml`** — version bump 0.1.6 → 0.1.7

## Why the tests are hard

**Gate-state tests:** Four separate assertions because a partial fix could pass
some but not all — a fix that still falls through to dispatch passes the
state-assertion test but fails `does_not_call_dispatch`; a fix that charges the
retry budget before catching the error passes state but fails
`does_not_increment_retry_count`.

**Allowlist tests:** The `"failed_unrecoverable"` case is the hardest — it is a
valid SM arc from `"failed_retrying"`, so it passes both the old truthy check and
SM arc validation. The only observable difference between old and fixed code is
whether `dispatch_stage` is called with a terminal state, which is what the test
asserts.

## Test plan

- [x] 102/102 tests pass
- [x] ruff check + ruff format clean
- [x] mypy clean
- [x] All pre-commit hooks pass across all commits
