### PR TITLE
v0.1.9 refactor: separate framework metadata from caller training_info in save_merged_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.9] — 2026-05-05
+
+### Changed
+
+- **`save_merged_model` checkpoint format redesigned** — Framework integrity fields (`format`, `peft_merged`, `requires_peft`) are now stored exclusively in `checkpoint["metadata"]`. Caller-supplied training provenance (epochs, metrics, git SHA, etc.) is stored in a separate `checkpoint["training_info"]` top-level key, written only when the caller provides a non-empty dict. The two namespaces can no longer interfere — reserved key names in `training_info` are preserved intact rather than silently dropped. Parameter renamed from `extra_metadata` to `training_info` for honesty. Old checkpoints (no `training_info` key) load cleanly — `load_merged_model` reads only `checkpoint["metadata"]`.
+
+### Tests
+
+- **Merger test suite updated for new checkpoint layout** — `test_training_info_stored_at_separate_checkpoint_key` (renamed from `test_extra_metadata_merged_into_metadata_dict`) asserts that caller provenance lives in `checkpoint["training_info"]` and that framework fields are absent from it. `test_training_info_cannot_affect_metadata_even_with_reserved_key_names` (renamed from `test_extra_metadata_cannot_clobber_framework_defaults`) proves physical isolation: the same key name in `training_info` does not affect `metadata`. Added: absence assertion verifying `training_info` is not written when caller provides nothing.
+
 ## [0.1.8] — 2026-05-05
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -409,13 +409,9 @@ and the audit, but each wants a callsite enumeration before shipping.
 
 ---
 
-### 30. `save_merged_model` metadata layout — cleaner separation of framework vs caller keys
+### ~~30. `save_merged_model` metadata layout — cleaner separation of framework vs caller keys~~
 
-**What:** `ml_engine/export/merger.py:save_merged_model` merges `extra_metadata` into a single `metadata` dict alongside framework integrity fields (`format`, `peft_merged`, `requires_peft`). The current fix (PR fix/xfails-and-f841) applies `extra_metadata` first then overwrites with framework keys — so callers silently lose any reserved keys they pass. A cleaner design would separate the two layers into distinct checkpoint keys (e.g. `checkpoint["metadata"]` for framework fields, `checkpoint["training_info"]` for caller-provided provenance), or raise explicitly when `extra_metadata` contains reserved keys.
-
-**Why deferred:** The silent-overwrite fix is the minimal correct change that makes `load_merged_model`'s format-detection invariant load-bearing. A structural redesign touches the on-disk checkpoint format (breaking change for existing `.pth` files) and all callers of `save_merged_model` and `load_merged_model`. Not worth doing mid-PR.
-
-**Files to touch:** `ml_engine/export/merger.py`, `ml_engine/export/packager.py` (passes `training_info` as `extra_metadata`), any tests that introspect `checkpoint["metadata"]` directly.
+**Completed:** v0.1.9 (2026-05-05) — `checkpoint["metadata"]` now holds only the three framework integrity fields (`format`, `peft_merged`, `requires_peft`). Caller provenance lives in the separate `checkpoint["training_info"]` key, written only when non-empty. Parameter renamed `extra_metadata` → `training_info`. `packager.py` updated to match. Tests updated: `test_extra_metadata_merged_into_metadata_dict` → `test_training_info_stored_at_separate_checkpoint_key` (checks separation); `test_extra_metadata_cannot_clobber_framework_defaults` → `test_training_info_cannot_affect_metadata_even_with_reserved_key_names` (shows physical isolation). `load_merged_model` unchanged — it only reads `checkpoint["metadata"]` so old checkpoints (no `training_info` key) load cleanly.
 
 ---
 

--- a/ml_engine/export/merger.py
+++ b/ml_engine/export/merger.py
@@ -67,7 +67,7 @@ def save_merged_model(
     model: nn.Module,
     output_path: Path,
     class_names: Optional[list] = None,
-    extra_metadata: Optional[Dict[str, Any]] = None,
+    training_info: Optional[Dict[str, Any]] = None,
     model_name: str = "grounding_dino",
 ) -> Path:
     """
@@ -76,13 +76,16 @@ def save_merged_model(
     Saves a checkpoint that can be loaded without PEFT:
     - model_state_dict: Model weights
     - class_names: Classes the model was trained on
-    - metadata: Training info, version, etc.
+    - metadata: Framework integrity fields (format, peft_merged, requires_peft)
+    - training_info: Caller-supplied training provenance (epochs, metrics, etc.)
 
     Args:
         model: Merged model (after merge_lora_weights)
         output_path: Path to save .pth file
         class_names: List of class names used in training
-        extra_metadata: Additional metadata to include
+        training_info: Caller-supplied training provenance; stored under a
+            separate top-level checkpoint key so it cannot interfere with
+            framework integrity fields in ``metadata``.
 
     Returns:
         Path to saved checkpoint
@@ -94,27 +97,24 @@ def save_merged_model(
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Build checkpoint. Explicit `Dict[str, Any]` annotation prevents mypy
-    # from inferring the dict literal's value type as `Collection[Any]` (the
-    # common ancestor of OrderedDict[str, Tensor], list, and dict). With the
-    # widened inference, `checkpoint["metadata"].update(extra_metadata)` would
-    # fail with `"Collection[Any]" has no attribute "update"`.
-    # extra_metadata applied first; framework keys appended after so they
-    # cannot be overwritten. See TODOS.md for a cleaner long-term design.
-    metadata: Dict[str, Any] = dict(extra_metadata) if extra_metadata else {}
-    metadata.update(
-        {
-            "format": f"merged_{model_name}",
-            "peft_merged": True,
-            "requires_peft": False,
-        }
-    )
+    # `metadata` holds only the three framework integrity fields read by
+    # load_merged_model. Caller provenance lives in the separate
+    # `training_info` key so the two namespaces cannot interfere.
+    # Explicit `Dict[str, Any]` annotation prevents mypy from widening the
+    # literal's value type to `Collection[Any]`.
+    metadata: Dict[str, Any] = {
+        "format": f"merged_{model_name}",
+        "peft_merged": True,
+        "requires_peft": False,
+    }
 
     checkpoint: Dict[str, Any] = {
         "model_state_dict": model.state_dict(),
         "class_names": class_names or [],
         "metadata": metadata,
     }
+    if training_info:
+        checkpoint["training_info"] = dict(training_info)
 
     # Save
     torch.save(checkpoint, output_path)

--- a/ml_engine/export/merger.py
+++ b/ml_engine/export/merger.py
@@ -85,7 +85,9 @@ def save_merged_model(
         class_names: List of class names used in training
         training_info: Caller-supplied training provenance; stored under a
             separate top-level checkpoint key so it cannot interfere with
-            framework integrity fields in ``metadata``.
+            framework integrity fields in ``metadata``. Falsy values (None,
+            empty dict) are treated identically — the key is omitted from
+            the checkpoint entirely.
 
     Returns:
         Path to saved checkpoint

--- a/ml_engine/export/packager.py
+++ b/ml_engine/export/packager.py
@@ -78,7 +78,7 @@ def create_export_package(
             model=merged_model,
             output_path=model_path,
             class_names=class_names,
-            extra_metadata=training_info,
+            training_info=training_info,
             model_name=model_name,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grounded-segment-anything"
-version = "0.1.8"
+version = "0.1.9"
 description = "ML platform: Grounding DINO + SAM for auto-labeling, training, and inference"
 requires-python = ">=3.10,<3.11"
 dependencies = [

--- a/tests/unit/ml_engine/export/test_merger.py
+++ b/tests/unit/ml_engine/export/test_merger.py
@@ -3,9 +3,6 @@ Unit tests for ml_engine.export.merger — written adversarially.
 
 Covers the three branches of `merge_lora_weights`, `save_merged_model`'s
 metadata + class-name handling, and `load_merged_model`'s error paths.
-Specifically tests the edges where the current implementation is sloppy
-or surprising — those tests are marked `xfail` with a clear reason so
-they act as tracked-but-pending design issues, not silent green stamps.
 
 Stubs duck-type the PEFT shape (hasattr-based check) using lightweight
 real classes — no PEFT, no GroundingDINO, no actual LoRA. Keeps the

--- a/tests/unit/ml_engine/export/test_merger.py
+++ b/tests/unit/ml_engine/export/test_merger.py
@@ -197,6 +197,7 @@ class TestSaveMergedModel:
         assert ckpt["metadata"]["format"] == "merged_grounding_dino"
         assert ckpt["metadata"]["peft_merged"] is True
         assert ckpt["metadata"]["requires_peft"] is False
+        assert "training_info" not in ckpt  # absent when caller provides none
 
     def test_class_names_round_trip(self, tmp_path: Path):
         model = _TinyModel()
@@ -225,40 +226,47 @@ class TestSaveMergedModel:
 
         assert ckpt_none["class_names"] == ckpt_empty["class_names"] == []
 
-    def test_extra_metadata_merged_into_metadata_dict(self, tmp_path: Path):
+    def test_training_info_stored_at_separate_checkpoint_key(self, tmp_path: Path):
+        """Caller provenance lives in checkpoint['training_info'], not inside metadata."""
         model = _TinyModel()
         out = tmp_path / "model.pth"
 
         save_merged_model(
             model,
             out,
-            extra_metadata={"epochs": 12, "mAP50": 0.83, "git_sha": "abc1234"},
+            training_info={"epochs": 12, "mAP50": 0.83, "git_sha": "abc1234"},
         )
 
         ckpt = torch.load(out, map_location="cpu", weights_only=False)
-        # Defaults still present
+        # Framework integrity fields stay in metadata
         assert ckpt["metadata"]["format"] == "merged_grounding_dino"
-        # Extras layered in
-        assert ckpt["metadata"]["epochs"] == 12
-        assert ckpt["metadata"]["mAP50"] == 0.83
-        assert ckpt["metadata"]["git_sha"] == "abc1234"
+        assert ckpt["metadata"]["peft_merged"] is True
+        # Caller provenance is under its own key, not mixed into metadata
+        assert ckpt["training_info"]["epochs"] == 12
+        assert ckpt["training_info"]["mAP50"] == 0.83
+        assert ckpt["training_info"]["git_sha"] == "abc1234"
+        assert "epochs" not in ckpt["metadata"]
 
-    def test_extra_metadata_cannot_clobber_framework_defaults(self, tmp_path: Path):
+    def test_training_info_cannot_affect_metadata_even_with_reserved_key_names(self, tmp_path: Path):
         """
-        A caller passing extra_metadata={'peft_merged': False, 'format': 'CUSTOM'}
-        should NOT be able to silently invert the framework's own metadata. Currently
-        it can. This test asserts the desired (safer) behavior; xfail tracks the bug.
+        Passing keys that share names with framework fields (peft_merged, format)
+        inside training_info does not corrupt checkpoint['metadata']. The two
+        namespaces are physically separate — no silent overwrite, no data loss.
         """
-        out = tmp_path / "clobbered.pth"
+        out = tmp_path / "model.pth"
         save_merged_model(
             _TinyModel(),
             out,
-            extra_metadata={"peft_merged": False, "format": "tampered"},
+            training_info={"peft_merged": False, "format": "tampered"},
         )
 
         ckpt = torch.load(out, map_location="cpu", weights_only=False)
-        assert ckpt["metadata"]["peft_merged"] is True  # FAILS today
-        assert ckpt["metadata"]["format"] == "merged_grounding_dino"  # FAILS today
+        # Framework metadata is unaffected
+        assert ckpt["metadata"]["peft_merged"] is True
+        assert ckpt["metadata"]["format"] == "merged_grounding_dino"
+        # Caller's values are preserved intact under training_info
+        assert ckpt["training_info"]["peft_merged"] is False
+        assert ckpt["training_info"]["format"] == "tampered"
 
     def test_creates_parent_directories(self, tmp_path: Path):
         model = _TinyModel()


### PR DESCRIPTION
## Summary

**Checkpoint format redesign** — `save_merged_model` now stores framework integrity fields exclusively in `checkpoint["metadata"]` and caller-supplied provenance in a separate `checkpoint["training_info"]` key.

- `checkpoint["metadata"]` → framework only: `format`, `peft_merged`, `requires_peft`
- `checkpoint["training_info"]` → caller provenance: epochs, metrics, git SHA, etc. (written only when non-empty; omitted when caller passes `None` or nothing)
- Parameter renamed: `extra_metadata` → `training_info` for clarity
- `packager.py` call site updated to match
- `load_merged_model` unchanged — reads only `checkpoint["metadata"]`, old checkpoints load cleanly

Closes #73.

## Test Coverage


Tests: 21 → 21 (names updated, no new tests needed — the existing tests fully cover the new paths)

## Pre-Landing Review

2 issues found — both auto-fixed:
- [AUTO-FIXED] `test_merger.py:7` — module docstring still referenced removed `xfail` markers
- [AUTO-FIXED] `merger.py` docstring — did not document that `training_info={}` is treated same as `None`

## Plan Completion

- [x] `checkpoint["metadata"]` holds only the three framework integrity fields
- [x] Caller provenance moved to `checkpoint["training_info"]` top-level key
- [x] Written only when caller supplies a non-empty dict (falsy → key absent)
- [x] Parameter renamed `extra_metadata` → `training_info`
- [x] `packager.py` updated at call site
- [x] Separation test renamed + assertions updated
- [x] Isolation test renamed + now passes by design (not xfail)
- [x] Absence assertion added for `training_info` when caller provides nothing
- [x] `load_merged_model` left unchanged (backward-compatible)
- [x] TODOS.md updated: 30 marked complete (v0.1.9)

## TODOS

- **30** `save_merged_model` metadata layout redesign — marked complete (v0.1.9, 2026-05-05)

## Test plan
- [x] All merger unit tests pass (21/21)
- [x] Pre-commit hooks pass (ruff format, ruff check, mypy, ast check)
- [x] Adversarial review: no in-branch blockers found