### PR TITLE
v0.1.17 test: class-scoped criterion fixture for GIoU invariants (closes #84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.17] — 2026-05-08
+
+### Tests
+
+- **`TestBuildCriterionGIoUInvariants` class-scoped `criterion` fixture (closes #84)** — The seven GIoU invariant tests previously rebuilt the criterion ~33 times (every `_giou_loss` call constructed a new `GroundingDINOCriterion` + `HungarianMatcher` with a 7-decoder-layer aux/encoder weight dict). New `@pytest.fixture(scope="class") def criterion` builds it once per class; `_giou_loss` now takes the fixture as its first argument and the seven test methods inject it. Verified via patched call counter: `build_criterion` invocation count drops to 1 in single-process runs. Trims ~3s off `tests/integration/test_ml_pipeline_cpu.py`. No assertion or test-logic changes; `GroundingDINOCriterion.forward()` is a stateless `nn.Module` (no `self.X = ...`, no buffers, no RNG ops on the path used by these tests), so sharing across the class is correctness-preserving. CI uses `pytest-xdist --dist=loadscope`, which keeps an entire class on one worker — fixture builds exactly once per class per test run.
+
 ## [0.1.16] — 2026-05-08
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -551,31 +551,6 @@ Affected rules: `changes_size`, `multiple_objects`, and `distance=close` at all 
 
 ---
 
-### 39. Class-scoped fixture for `build_criterion` in GIoU invariant tests
-
-**Priority:** P3 (cosmetic perf — does not affect correctness).
-
-**What:** [tests/integration/test_ml_pipeline_cpu.py::TestBuildCriterionGIoUInvariants](tests/integration/test_ml_pipeline_cpu.py#L561) calls `build_criterion(num_classes=1)` inside `_giou_loss(...)` on every invocation. Across the 8 tests in the class, the criterion gets rebuilt ~33 times. `build_criterion` reads YAML and constructs `GroundingDINOCriterion + HungarianMatcher` — non-trivial.
-
-**Why:** The 8-test class adds ~3 seconds of redundant setup to the CPU integration suite. Not flake-inducing, just wasteful.
-
-**Fix:** Hoist criterion to a class-scoped pytest fixture and pass it into `_giou_loss`:
-```python
-@pytest.fixture(scope="class")
-def criterion(self):
-    return build_criterion(num_classes=1)
-
-@staticmethod
-def _giou_loss(criterion, pred_box, gt_box):
-    ...
-```
-
-**Depends on / blocked by:** None.
-
-**Surfaced:** `/review` of `integration-tests/ml-pipeline-cpu` (2026-05-08).
-
----
-
 ### 40. Pin loose `pytest.raises` contracts across the test suite (dual-acceptance audit)
 
 **Priority:** P3 (P2 cases A/B already fixed inline; remaining 6 are lower-impact but same disease).
@@ -633,3 +608,4 @@ Item numbers are stable so commit messages and PR descriptions referencing
 - **#19** `_keep_higher_p` KeyError on missing `p` key ✅ — Added guard at `characteristic_translator.py:1109` that raises `ValueError` with a clear message when either params dict is missing `p`. xfail test promoted to passing regression guard (93 pass, 0 xfail). Shipped 2026-04-28.
 - **#25** `CharacteristicSchemaIntegrity` tests cover only 5 of 9 characteristics + `alpha_corf` typo ✅ — All 4 `@pytest.mark.parametrize` decorators in `TestCharacteristicSchemaIntegrity` now use `_ALL_CHARACTERISTICS = list(CharacteristicTranslator.CHARACTERISTIC_RULES.keys())` (derived from production dict, auto-updates when new characteristics are added). `alpha_corf` → `alpha_coef` typo corrected in `semi_transparent/low/RandomFog`. 36 tests pass (up from 20). Shipped 2026-05-06.
 - **#37** Pin NaN-handling contract in NaN-predictions test ✅ — Renamed `test_nan_predictions_produce_non_finite_or_raise` → `test_nan_predictions_propagate_to_loss`, dropped the `try/except (ValueError, RuntimeError): pass` dual-accept, tightened `not isfinite` → `isnan` (excludes ±Inf). Verified live behavior: SegmentationLoss propagates NaN through to loss output, which is what AMP `GradScaler.step()` expects so it can detect bad steps and skip the optimizer update. Sibling P2 cases A/B (`test_sam_lora.py:587`, `test_validators.py:1016`) fixed in the same commit; 6 lower-impact dual-accept sites filed as #40. Shipped 2026-05-08.
+- **#39** Class-scoped `build_criterion` fixture for GIoU invariant tests ✅ — `TestBuildCriterionGIoUInvariants` now uses `@pytest.fixture(scope="class") def criterion`; `_giou_loss` takes the fixture as its first argument; the seven test methods inject it. `build_criterion` invocation count drops from ~33 to 1 (verified via patched call counter). ~3s shaved off the CPU integration suite. Shipped v0.1.17, 2026-05-08.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grounded-segment-anything"
-version = "0.1.16"
+version = "0.1.17"
 description = "ML platform: Grounding DINO + SAM for auto-labeling, training, and inference"
 requires-python = ">=3.10,<3.11"
 dependencies = [

--- a/tests/integration/test_ml_pipeline_cpu.py
+++ b/tests/integration/test_ml_pipeline_cpu.py
@@ -566,11 +566,19 @@ class TestBuildTeacherTrainingConfig:
 
 
 class TestBuildCriterionGIoUInvariants:
+    @pytest.fixture(scope="class")
+    def criterion(self):
+        # build_criterion constructs GroundingDINOCriterion + HungarianMatcher
+        # with the full aux/encoder weight_dict. Building once per class (instead
+        # of ~33 times across these tests) shaves ~3s off the suite. Safe to
+        # share: the criterion is a stateless nn.Module — forward() only reads
+        # from self.
+        return build_criterion(num_classes=1)
+
     @staticmethod
-    def _giou_loss(pred_box: torch.Tensor, gt_box: torch.Tensor) -> float:
+    def _giou_loss(criterion, pred_box: torch.Tensor, gt_box: torch.Tensor) -> float:
         """loss_giou for a 1-pred / 1-target setup. Uses very-low logits so
         classification cost is constant and matching is forced (1x1)."""
-        criterion = build_criterion(num_classes=1)
         outputs = {
             "pred_logits": torch.full((1, 1, 256), -100.0),
             "pred_boxes": pred_box.unsqueeze(0),
@@ -585,7 +593,7 @@ class TestBuildCriterionGIoUInvariants:
         return criterion(outputs, targets)["loss_giou"].item()
 
     @pytest.mark.parametrize("side", [0.2, 0.05, 0.01])
-    def test_self_match_loss_is_zero_across_box_sizes(self, side: float) -> None:
+    def test_self_match_loss_is_zero_across_box_sizes(self, criterion, side: float) -> None:
         """Perfect prediction must give loss_giou == 0 for ANY non-degenerate box.
 
         With the original +1e-6 in the IoU denominator the bias scales as
@@ -593,14 +601,14 @@ class TestBuildCriterionGIoUInvariants:
         side=0.01 → 9.9e-3 (~1% loss on perfect prediction).
         """
         box = torch.tensor([[0.5, 0.5, side, side]])
-        loss = self._giou_loss(box, box)
+        loss = self._giou_loss(criterion, box, box)
         predicted_eps_bias = 1e-6 / (side * side + 1e-6)
         assert loss == pytest.approx(0.0, abs=1e-6), (
             f"side={side}: loss_giou={loss:.3e}, expected ~0. "
             f"Predicted +1e-6 epsilon bias = {predicted_eps_bias:.3e}"
         )
 
-    def test_self_match_loss_invariant_to_box_size(self) -> None:
+    def test_self_match_loss_invariant_to_box_size(self, criterion) -> None:
         """Perfect-match loss_giou must not depend on box size.
 
         Catches the epsilon bug as a *ratio* property: even if absolute values
@@ -609,41 +617,41 @@ class TestBuildCriterionGIoUInvariants:
         """
         sides = [0.2, 0.05, 0.01]
         losses = {
-            s: self._giou_loss(torch.tensor([[0.5, 0.5, s, s]]), torch.tensor([[0.5, 0.5, s, s]]))
+            s: self._giou_loss(criterion, torch.tensor([[0.5, 0.5, s, s]]), torch.tensor([[0.5, 0.5, s, s]]))
             for s in sides
         }
         max_loss = max(losses.values())
         assert max_loss < 1e-5, f"loss_giou varies with box size (denominator bias likely): {losses}"
 
-    def test_giou_loss_symmetric(self) -> None:
+    def test_giou_loss_symmetric(self, criterion) -> None:
         """GIoU is symmetric: loss(A as pred, B as gt) == loss(B as pred, A as gt)."""
         a = torch.tensor([[0.3, 0.4, 0.2, 0.15]])
         b = torch.tensor([[0.6, 0.5, 0.25, 0.3]])
-        ab = self._giou_loss(a, b)
-        ba = self._giou_loss(b, a)
+        ab = self._giou_loss(criterion, a, b)
+        ba = self._giou_loss(criterion, b, a)
         assert ab == pytest.approx(ba, abs=1e-6), f"asymmetric: {ab} vs {ba}"
 
-    def test_giou_loss_translation_invariant(self) -> None:
+    def test_giou_loss_translation_invariant(self, criterion) -> None:
         """Translating both boxes by the same offset preserves loss_giou."""
         a = torch.tensor([[0.3, 0.3, 0.2, 0.2]])
         b = torch.tensor([[0.4, 0.4, 0.2, 0.2]])
         offset = torch.tensor([[0.1, 0.1, 0.0, 0.0]])
-        baseline = self._giou_loss(a, b)
-        shifted = self._giou_loss(a + offset, b + offset)
+        baseline = self._giou_loss(criterion, a, b)
+        shifted = self._giou_loss(criterion, a + offset, b + offset)
         assert baseline == pytest.approx(shifted, abs=1e-6), f"translation-variant: {baseline} vs {shifted}"
 
-    def test_giou_loss_monotone_under_separation(self) -> None:
+    def test_giou_loss_monotone_under_separation(self, criterion) -> None:
         """As prediction translates away from target, loss_giou must monotonically
         increase. Catches sign / direction bugs in the GIoU enclosing-box term."""
         target = torch.tensor([[0.5, 0.5, 0.2, 0.2]])
         prev = -float("inf")
         for shift in [0.0, 0.05, 0.1, 0.2, 0.4, 0.7]:
             pred = target + torch.tensor([[shift, 0.0, 0.0, 0.0]])
-            loss = self._giou_loss(pred, target)
+            loss = self._giou_loss(criterion, pred, target)
             assert loss >= prev - 1e-6, f"non-monotone at shift={shift}: loss={loss:.4f} < prev={prev:.4f}"
             prev = loss
 
-    def test_giou_loss_upper_bound_for_disjoint_boxes(self) -> None:
+    def test_giou_loss_upper_bound_for_disjoint_boxes(self, criterion) -> None:
         """Far-apart small boxes → loss_giou approaches 2.0 (giou → -1).
 
         pred at (0,0)-(0.05,0.05), gt at (0.95,0.95)-(1.0,1.0):
@@ -653,10 +661,10 @@ class TestBuildCriterionGIoUInvariants:
         """
         pred = torch.tensor([[0.025, 0.025, 0.05, 0.05]])
         gt = torch.tensor([[0.975, 0.975, 0.05, 0.05]])
-        loss = self._giou_loss(pred, gt)
+        loss = self._giou_loss(criterion, pred, gt)
         assert 1.9 < loss < 2.0, f"expected ~1.995, got {loss}"
 
-    def test_giou_loss_in_valid_range(self) -> None:
+    def test_giou_loss_in_valid_range(self, criterion) -> None:
         """For any pair of non-degenerate boxes: loss_giou ∈ [0, 2]."""
         torch.manual_seed(0)
         for _ in range(20):
@@ -667,5 +675,5 @@ class TestBuildCriterionGIoUInvariants:
             wh_b = torch.rand(2) * 0.35 + 0.05
             a = torch.cat([cxcy_a, wh_a]).unsqueeze(0)
             b = torch.cat([cxcy_b, wh_b]).unsqueeze(0)
-            loss = self._giou_loss(a, b)
+            loss = self._giou_loss(criterion, a, b)
             assert 0.0 - 1e-6 <= loss <= 2.0 + 1e-6, f"out of range: {loss}"


### PR DESCRIPTION
## Summary
- `TestBuildCriterionGIoUInvariants` now uses a class-scoped `criterion` fixture; `_giou_loss` accepts it as the first argument and the seven test methods inject it.
- `build_criterion` invocation count drops from ~33 to 1 (verified via patched call counter); ~3s shaved off the CPU integration suite.
- Bumps version to v0.1.17, updates CHANGELOG, marks TODO 39 complete.

## Test Coverage
Test-only refactor — no application code changed. All 2348 tests pass post-change (1 skipped + 1 xfailed are pre-existing/expected). The fixture refactor preserves every assertion in every test method.

## Pre-Landing Review
No issues found. Pass 1 (SQL/LLM): N/A. Pass 2 (informational): clean — naming clear, comment explains why fixture is class-scoped and why sharing is safe (stateless `nn.Module`).

## Adversarial Review (Claude subagent)
- Verified `GroundingDINOCriterion.forward()` and helpers do **not** mutate `self` — no buffers, no caches, no `.train()`/`.eval()` flips, no RNG ops on the path used by these tests.
- CI uses `pytest-xdist --dist=loadscope` (`.github/workflows/ci.yml`), which keeps a class on one worker — fixture builds exactly once per class per test run.
- One auto-fix applied: corrected fixture comment ("reads YAML" → constructs criterion + matcher with the full aux/encoder weight_dict). `build_criterion` uses paper literals, not YAML.

**Recommendation: ship** — no exploitable finding; criterion is verifiably stateless, parametrize+fixture works, RNG-isolated, training-mode-immune.

## Scope Drift
**Scope: CLEAN.** Intent: fix #84. Delivered: only `tests/integration/test_ml_pipeline_cpu.py` (the class), plus version + CHANGELOG + TODOS bookkeeping.

## Plan Completion
Closes #84. Acceptance criteria met:
- ✅ All 7 test methods (1 parametrized × 3, total 9 items) use the shared fixture
- ✅ `build_criterion` invocation drops from ~33 to 1
- ✅ ~3-second runtime reduction on CPU integration tests
- ✅ No test logic changes; same assertions maintained
- ✅ No regressions across the 2348-test suite

## Test plan
- [x] All tests pass (`make test`): 2348 passed, 1 skipped, 1 xfailed in 36.51s
- [x] Targeted class re-verified: `pytest tests/integration/test_ml_pipeline_cpu.py::TestBuildCriterionGIoUInvariants` → 9 passed in 4.47s
- [x] Pre-commit hooks: ruff check + ruff format + mypy all pass