### PR TITLE
v0.1.21 test: pin loose pytest.raises contracts across test suite (closes #87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.21] — 2026-05-11
+
+### Tests
+
+- **Pin loose `pytest.raises` contracts across the suite (closes #87)** — Replaced 7 multi-exception or `Exception`-bare catches with specific exception types plus `match=` regex patterns. Each pin now names the exact contract the test exercises: `SegmentationLoss` batch-size mismatch (ValueError), GroundingDINO box-shape contract (RuntimeError from `torch.cdist`), missing `class_mapping` key (KeyError), SAM spatial-mismatch (ValueError from BCE), Redis pipeline-failure propagation (RuntimeError), empty-polygon validation (ValueError), and matmul dtype-mismatch (RuntimeError). Loose `(A, B)` tuples and bare `pytest.raises(Exception)` would let either of two distinct outcomes silently pass — the pinned form fails loudly if the contract drifts, catching regressions in either direction.
+
+### Changed
+
+- **`SegmentationLoss.forward` now raises `ValueError` with a stable message** when `pred_masks.shape[:2] != target_masks.shape[:2]`. Previously the same shape mismatch surfaced as a downstream `torch.view(b*n, -1)` `RuntimeError` whose message varies across PyTorch versions ("shape '[3, -1]' is invalid for input of size 128"). The explicit check pins the [B, N] alignment contract upstream so the test can pin a typed exception with a stable regex.
+- **`_normalize_to_rle` in `ml_engine/data/validators.py` now rejects empty polygon lists** (`[]`, `[[]]`, etc.) with a stable `ValueError` before pycocotools' `frPyObjects` raises base `Exception("input type is not supported.")`. Same motivation as above — a typed exception with a useful message instead of a bare `Exception` the test can't pin.
+
 ## [0.1.20] — 2026-05-11
 
 ### Changed

--- a/TODOS.md
+++ b/TODOS.md
@@ -532,36 +532,6 @@ Affected rules: `changes_size`, `multiple_objects`, and `distance=close` at all 
 ---
 
 
-### 40. Pin loose `pytest.raises` contracts across the test suite (dual-acceptance audit)
-
-**Priority:** P3 (P2 cases A/B already fixed inline; remaining 6 are lower-impact but same disease).
-
-**What:** A grep audit done while filing #37 found 8 dual-acceptance test sites — tests whose assertion accepts two distinct outcomes, masking regression in either direction. Two were fixed inline (see "Audit context" below). Six remain. Each accepts a loose pair like `(RuntimeError, ValueError)` or even bare `pytest.raises(Exception)`, which catches `AssertionError` from broken test setup and lets the contract drift silently between explicit validation and incidental torch/dict errors.
-
-**The six remaining sites:**
-
-1. [tests/integration/test_ml_pipeline_cpu.py:327](tests/integration/test_ml_pipeline_cpu.py#L327) — `pytest.raises((RuntimeError, ValueError))` on batch-size mismatch in `SegmentationLoss`. Today only `RuntimeError` fires (torch reshape). Pin to `RuntimeError` with a `match`, OR add an explicit `ValueError` check in `losses.py` and pin to that.
-
-2. [tests/integration/test_ml_pipeline_cpu.py:385](tests/integration/test_ml_pipeline_cpu.py#L385) — `pytest.raises((RuntimeError, AssertionError))` on (M, 3) boxes. Assertion vs torch op are very different bug classes; sibling `test_missing_token_labels_raises` already pins `AssertionError` with a match. Match that.
-
-3. [tests/integration/test_ml_pipeline_cpu.py:540](tests/integration/test_ml_pipeline_cpu.py#L540) — `pytest.raises((KeyError, ValueError))` on missing `class_mapping`. Today `KeyError` (native dict access) fires. Pin to that, OR add explicit `ValueError` validation in `build_teacher_training_config` and pin to that.
-
-4. [tests/unit/ml_engine/test_sam_lora.py:533](tests/unit/ml_engine/test_sam_lora.py#L533) — `pytest.raises((RuntimeError, ValueError))` on spatial H/W mismatch. Today only `RuntimeError` fires (no explicit spatial check in `losses.py`). Pin to `RuntimeError` with `match`, OR add explicit check.
-
-5. `tests/contract/test_redis_store_invariants.py` (~line 244) — bare `pytest.raises(Exception)` while injecting a specific `RuntimeError`. Pin to the injected type.
-
-6. [tests/unit/ml_engine/data/test_validators.py:337](tests/unit/ml_engine/data/test_validators.py#L337) — bare `pytest.raises(Exception)` for `compute_bbox_from_mask([[]])`. Investigate the actual exception pycocotools throws, pin to that specific type with a `match`.
-
-**Why:** A loose `pytest.raises((RuntimeError, ValueError))` accepts a regression where the explicit `raise ValueError("clear message")` is removed and torch's vague `RuntimeError: shape ... is invalid` takes over. Users go from a helpful error to a torch internal one with no test signal. `pytest.raises(Exception)` is even worse — it accepts `AssertionError` from a broken test setup. The pattern is consistent: when the test author wasn't sure which exception fires, they accepted both rather than running the code once and pinning.
-
-**Audit context:** Done as a sweep after `/review` flagged TODO #37 (the parent of this disease). Eight sites total found across `tests/`. Two P2 cases already fixed inline on `integration-tests/ml-pipeline-cpu` (2026-05-08): `tests/unit/ml_engine/test_sam_lora.py:587` (sibling integration test had the right pin: `match=r"iou_predictions must be shape \[B, N\]"`) and `tests/unit/ml_engine/data/test_validators.py:1016-1032` (explicit "either succeeds or raises clear error" comment + redundant `(ValueError, Exception)` catch — verified live behavior succeeds gracefully, pinned to that).
-
-**Fix recipe per site:** (a) run the test with the loose `pytest.raises` removed to see which exception actually fires today; (b) decide whether that's the contract you want; (c) pin with `pytest.raises(SpecificType, match=r"distinguishing-phrase")`. If the contract should be a typed exception that doesn't exist yet, add the explicit `raise` in the source first.
-
-**Depends on / blocked by:** None. Each site is independent.
-
----
-
 ## Completed
 
 One-line stubs for items that have shipped. Long-form context (what shipped,
@@ -593,3 +563,4 @@ Item numbers are stable so commit messages and PR descriptions referencing
 - **#36** Test determinism — seed `_gdino_outputs` / `_gdino_targets` helpers ✅ — Module-level `@pytest.fixture(autouse=True) def _seed_torch_rng` calls `torch.manual_seed(0)` before every test in `tests/integration/test_ml_pipeline_cpu.py`. Boundary-condition failures on the ~10 helper-consuming tests now reproduce on rerun. Verified: 5 simulated runs return identical loss values; empirical pytest probe asserts seed-0 first-draw value (`0.4962565899`) inside a real test body. `test_giou_loss_in_valid_range` reseeds itself to 0, no behavior change. 2348 tests still pass. Shipped v0.1.18, 2026-05-09.
 - **#38** Dtype-aware clamp threshold in `ml_engine/utils/box_ops.py` ✅ — Replaced literal `clamp(min=1e-12)` with `clamp(min=torch.finfo(t.dtype).tiny)` in both `box_iou` and `generalized_box_iou`. Floor adapts: 1.18e-38 fp32, 6.10e-5 fp16, 2.22e-308 fp64. Prevents 0/0 NaN on degenerate boxes in any precision. New `TestBoxOpsDtypeSafety` covers fp16/bf16/fp32/fp64 self-IoU/GIoU=1, distinct-pair GIoU close to fp64 truth at normal scale, no NaN/Inf on degenerate boxes, plus a regression-canary that fails loudly if `torchvision.ops.box_area` ever stops upcasting fp16/bf16 → fp32. Adversarial review during ship surfaced a small-fp16-box GIoU distortion on the all-fp16 path (filed as #42); production paths are shielded structurally. Shipped v0.1.19, 2026-05-09.
 - **#42** fp32-promote inputs inside `box_iou` / `generalized_box_iou` ✅ — `_LOW_PRECISION = (fp16, bf16)` + `_promote_target` helper using `torch.promote_types` lifts low-precision inputs to fp32 (or fp64 if the other input is fp64) at function entry. Eliminates the 40%-off-truth small-fp16-box GIoU distortion #38's dtype-aware clamp introduced via the `enclosing` denominator. Dtype contract: fp16/bf16/fp32 → fp32 output, fp64 → fp64 preserved, mixed-dtype callers (e.g., `box_iou(fp16, fp64)`) promote to wider common type — `torch.promote_types`-based helper prevents silent fp64 downcast (caught by pre-landing adversarial review on the initial draft). New `test_distinct_pair_giou_small_boxes_match_fp64_on_same_coords` is the assertion that was impossible pre-#42 (matches fp64 result on same already-quantized coords at 1e-5 tolerance). `test_output_dtype_contract` extended to the full 4×4 dtype matrix (16 pairs) locking in the contract. Shipped v0.1.20, 2026-05-11.
+- **#40** Pin loose `pytest.raises` contracts across the test suite ✅ — Replaced 7 multi-exception or `Exception`-bare catches with specific exception types + `match=` regex pins. Sites: `SegmentationLoss` batch mismatch (ValueError), GroundingDINO box-shape (RuntimeError from `torch.cdist`), missing `class_mapping` (KeyError), SAM spatial mismatch (ValueError from BCE), Redis pipeline failure (RuntimeError), empty-polygon validation (ValueError), matmul dtype mismatch (RuntimeError). Two source-level fixes enable cleaner pins: `SegmentationLoss.forward` now raises a typed `ValueError` on pred↔target [B,N] disagreement (replaces brittle torch `view(b*n,-1)` error), and `_normalize_to_rle` rejects empty polygons with a typed `ValueError` (replaces pycocotools' base `Exception`). Final grep returns zero matches for `pytest.raises((` or `pytest.raises(Exception)` in `tests/`. 2355 tests + 36 subtests still pass. Shipped v0.1.21, 2026-05-11.

--- a/ml_engine/data/validators.py
+++ b/ml_engine/data/validators.py
@@ -443,7 +443,13 @@ def _normalize_to_rle(segmentation: Any, height: int, width: int) -> dict:
         Compressed RLE dict with bytes counts
     """
     if isinstance(segmentation, list):
-        # Polygon format -> convert to compressed RLE
+        # Polygon format -> convert to compressed RLE.
+        # Reject empty polygon lists (`[]`) or polygons containing empty arrays
+        # (`[[]]`) before calling pycocotools — its `frPyObjects` raises base
+        # `Exception("input type is not supported.")` for these, which masks
+        # the actual contract violation behind a generic exception.
+        if not segmentation or any(not p for p in segmentation):
+            raise ValueError("polygon segmentation must be a non-empty list of non-empty coordinate arrays")
         rles = mask_utils.frPyObjects(segmentation, height, width)
         return mask_utils.merge(rles)
 

--- a/ml_engine/training/losses.py
+++ b/ml_engine/training/losses.py
@@ -599,6 +599,22 @@ class SegmentationLoss(nn.Module):
                 "Multimask [B,N,K,H,W] must be reduced before passing to SegmentationLoss."
             )
         target_masks = targets["masks"]
+        if pred_masks.shape[:2] != target_masks.shape[:2]:
+            # SegmentationLoss expects index-aligned masks: pred[b, n] pairs with
+            # target[b, n]. In the SAM trainer that alignment comes from prompting
+            # SAM with GT boxes (so prompt i → mask i). The pred↔target [B, N]
+            # axis is enforced here. Without this check the downstream
+            # `view(b*n, -1)` raises a torch shape error whose message is brittle
+            # across PyTorch versions (e.g. "shape '[3, -1]' is invalid for input
+            # of size 128"); the explicit check pins a stable contract message.
+            # Note: valid_mask shape vs target_masks shape is NOT validated here.
+            # Production callers (model_trainers/sam.py) construct valid_mask
+            # from the same source as masks (`labels != -1`), so the two are
+            # guaranteed aligned in the only realistic call path.
+            raise ValueError(
+                f"pred_masks and target masks must have matching [B, N] dimensions; "
+                f"got pred_masks {tuple(pred_masks.shape)}, target masks {tuple(target_masks.shape)}"
+            )
         valid_mask = targets.get(
             "valid_mask",
             torch.ones(target_masks.shape[:2], dtype=torch.bool, device=target_masks.device),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grounded-segment-anything"
-version = "0.1.20"
+version = "0.1.21"
 description = "ML platform: Grounding DINO + SAM for auto-labeling, training, and inference"
 requires-python = ">=3.10,<3.11"
 dependencies = [

--- a/tests/contract/test_dtype_invariants.py
+++ b/tests/contract/test_dtype_invariants.py
@@ -91,8 +91,10 @@ class TestDtypePreservationThroughAutocast:
         model = tiny_attention_block  # fp32 params
         x_bf16 = torch.randn(2, 4, 16, dtype=torch.bfloat16)
 
-        with pytest.raises((RuntimeError, TypeError)):
-            # No autocast. fp32 weights + bf16 input → matmul error. Exact
-            # message varies by torch version; matching on exception type is
-            # enough — the key is that it raises instead of silently upcasting.
+        # PyTorch's matmul rejects mixed-dtype operands with
+        # ``RuntimeError("mat1 and mat2 must have the same dtype, but got
+        # BFloat16 and Float")``. Pinning to that string is precise; if a
+        # future torch reword keeps the spirit but drops one of the operand
+        # names, ``same dtype`` is the load-bearing fragment.
+        with pytest.raises(RuntimeError, match=r"same dtype"):
             _ = model(x_bf16)

--- a/tests/contract/test_redis_store_invariants.py
+++ b/tests/contract/test_redis_store_invariants.py
@@ -241,7 +241,10 @@ class TestPipelinedTransactionFailureDoesNotCorruptState:
             return _FailingPipeline(real_pipeline(*args, **kwargs))
 
         with patch.object(fake_redis, "pipeline", _patched_pipeline):
-            with pytest.raises(Exception):
+            # _FailingPipeline.execute() raises this exact RuntimeError mid-pipeline.
+            # store.update_job should propagate it (not swallow or rewrap), which
+            # is what enables the post-failure consistency assertions below.
+            with pytest.raises(RuntimeError, match=r"Simulated Redis failure mid-pipeline"):
                 store.update_job(job.id, status=JobStatus.COMPLETED)
 
         # After the failure: the job should NOT simultaneously be in running AND

--- a/tests/integration/test_ml_pipeline_cpu.py
+++ b/tests/integration/test_ml_pipeline_cpu.py
@@ -340,7 +340,9 @@ class TestSegmentationLossErrors:
         criterion = SegmentationLoss()
         preds = {"pred_masks": torch.rand(2, 1, 8, 8)}
         tgts = {"masks": torch.rand(3, 1, 8, 8), "valid_mask": torch.ones(3, 1, dtype=torch.bool)}
-        with pytest.raises((RuntimeError, ValueError)):
+        with pytest.raises(
+            ValueError, match=r"pred_masks and target masks must have matching \[B, N\] dimensions"
+        ):
             criterion(preds, tgts)
 
     def test_wrong_iou_predictions_shape_raises(self) -> None:
@@ -389,7 +391,12 @@ class TestBuildCriterionBasics:
             criterion(_gdino_outputs(), bad_targets)
 
     def test_boxes_wrong_shape_raises(self) -> None:
-        """(M, 3) boxes instead of (M, 4) — catches shape contract violations."""
+        """(M, 3) boxes instead of (M, 4) — catches shape contract violations.
+
+        Boxes with the wrong trailing dim flow into ``torch.cdist`` inside
+        ``HungarianMatcher``, which raises ``RuntimeError("X1 and X2 must
+        have the same number of columns. ...")``. Pin to that contract.
+        """
         criterion = build_criterion(num_classes=1)
         bad_targets = [
             {
@@ -398,7 +405,7 @@ class TestBuildCriterionBasics:
                 "token_labels": torch.zeros(2, 256),
             }
         ]
-        with pytest.raises((RuntimeError, AssertionError)):
+        with pytest.raises(RuntimeError, match=r"X1 and X2 must have the same number of columns"):
             criterion(_gdino_outputs(), bad_targets)
 
     def test_multi_class_produces_finite_losses(self) -> None:
@@ -553,7 +560,12 @@ class TestBuildTeacherTrainingConfig:
         dm = MagicMock()
         dm.get_dataset_info.return_value = {"num_classes": 1}  # no class_mapping
         dm.get_required_models.return_value = {"grounding_dino": "x.pt"}
-        with pytest.raises((KeyError, ValueError)):
+        # build_teacher_training_config does `dataset_info["class_mapping"]`
+        # inside its config dict literal — the natural KeyError surfaces the
+        # missing key by name. We pin the key name (the only stable thing in
+        # a Python KeyError repr) rather than adding defensive validation that
+        # would just duplicate the DataManager contract.
+        with pytest.raises(KeyError, match=r"class_mapping"):
             build_teacher_training_config(dm)
 
 

--- a/tests/unit/ml_engine/data/test_validators.py
+++ b/tests/unit/ml_engine/data/test_validators.py
@@ -332,9 +332,14 @@ class TestComputeBboxFromMask:
         assert bbox[1] + bbox[3] <= 480
 
     def test_empty_polygon_raises_error(self):
-        """Empty polygon should raise an exception."""
-        # pycocotools raises Exception for invalid input types
-        with pytest.raises(Exception):
+        """Empty polygon should raise a specific ValueError.
+
+        Pre-fix, ``mask_utils.frPyObjects([[]], ...)`` raised base
+        ``Exception("input type is not supported.")`` from pycocotools, which
+        is unpinnable. ``_normalize_to_rle`` now rejects empty polygon lists
+        upstream with a stable ValueError, so the test pins that contract.
+        """
+        with pytest.raises(ValueError, match=r"polygon segmentation must be a non-empty list of non-empty"):
             compute_bbox_from_mask([[]], height=480, width=640)
 
     # -------------------------------------------------------------------------

--- a/tests/unit/ml_engine/test_sam_lora.py
+++ b/tests/unit/ml_engine/test_sam_lora.py
@@ -521,7 +521,15 @@ class TestSegmentationLossEdgeCases:
         assert iou_preds.grad is not None and iou_preds.grad.abs().sum() > 0
 
     def test_spatial_mismatch_raises(self):
-        """Spatial size mismatch between pred_masks and target masks must raise."""
+        """Spatial size mismatch between pred_masks and target masks must raise.
+
+        Pred and target share [B, N] but disagree on H×W. After SegmentationLoss
+        flattens to [B*N, H*W], the BCE inside ``sigmoid_focal_loss`` raises
+        ``ValueError("Target size (..., 786432) must be the same as input size
+        (..., 196608)")``. Pin to that contract — anyone who refactors the
+        trainer to forget upscaling SAM's 256×256 decoder output to the input
+        resolution should get a loud, targeted failure here.
+        """
         from ml_engine.training.losses import SegmentationLoss
 
         B, N = 2, 3
@@ -530,7 +538,7 @@ class TestSegmentationLossEdgeCases:
             "masks": torch.randint(0, 2, (B, N, 512, 512)).float(),
             "valid_mask": torch.ones(B, N, dtype=torch.bool),
         }
-        with pytest.raises((RuntimeError, ValueError)):
+        with pytest.raises(ValueError, match=r"Target size .* must be the same as input size"):
             SegmentationLoss()(predictions, targets)
 
     def test_focal_zero_weight_removes_focal_from_total(self):

--- a/uv.lock
+++ b/uv.lock
@@ -498,7 +498,7 @@ wheels = [
 
 [[package]]
 name = "grounded-segment-anything"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "addict" },


### PR DESCRIPTION
## Summary
- **Pinned 7 loose `pytest.raises` sites** across `test_ml_pipeline_cpu.py`, `test_sam_lora.py`, `test_redis_store_invariants.py`, `test_validators.py`, and `test_dtype_invariants.py`. Each pin now names a specific exception type with a `match=` regex that documents the contract being exercised.
- **Two source-level fixes** enable cleaner pins (replacing brittle library-internal errors with stable typed exceptions): `SegmentationLoss.forward` validates pred↔target `[B, N]` alignment up front; `_normalize_to_rle` rejects empty polygon lists with `ValueError` before pycocotools raises bare `Exception`.
- Bumps to v0.1.21, marks TODO 40 complete.

## Test Coverage
Test-only diff plus two narrow source-validation additions. Each pinned site exercises an existing test path; no new tests needed (the pins lock in current behavior more strictly).

**Tests: 2355 passed, 36 subtests passed.** Targeted run of the 7 pinned tests + neighbors all pass.

## Adversarial Review
One actionable finding (**F2**): the new `SegmentationLoss` validation comment said "[B, N] contract must hold here" but only enforces pred↔target alignment, not pred↔valid_mask. Production callers (`model_trainers/sam.py`) construct `valid_mask` from the same source as `masks` (`labels != -1`), so the gap can't fire in real code. Applied comment-only fix: scoped the docstring honestly to "pred↔target axis" and added a note about why valid_mask alignment is structurally guaranteed in production.

Other findings (8 items) were classified as INVESTIGATE-only — regex stability check on `cdist` (stable since the op was added), empty-polygon edge cases (verified safe), validation order (no caller depends on the old brittle errors), and a pre-existing test-fidelity concern with the Redis pin (out of scope — the test mocks `RuntimeError` because the production code swallows actual `RedisError` subclasses; tracking-worthy but unchanged by this PR).

## Test plan
- [x] All tests pass (`make test`): 2355 passed, 1 skipped, 1 xfailed
- [x] Grep verifies zero loose patterns
- [x] Each pinned site exercises a real exception path (verified via empirical probe before pinning)
- [ ] Mypy on the diff (deferred — run when server load is lower)
